### PR TITLE
chore: replace SlenderBar BiConsumer with event-based state change system

### DIFF
--- a/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
@@ -36,11 +36,13 @@ import net.onelitefeather.cygnus.common.page.event.PageEvent;
 import net.onelitefeather.cygnus.common.util.Helper;
 import net.onelitefeather.cygnus.event.GameFinishEvent;
 import net.onelitefeather.cygnus.event.SlenderReviveEvent;
+import net.onelitefeather.cygnus.event.StaminaStateChangeEvent;
 import net.onelitefeather.cygnus.listener.PlayerChatListener;
 import net.onelitefeather.cygnus.listener.PlayerDeathListener;
 import net.onelitefeather.cygnus.listener.PlayerLoginListener;
 import net.onelitefeather.cygnus.listener.PlayerQuitListener;
 import net.onelitefeather.cygnus.listener.PlayerSpawnListener;
+import net.onelitefeather.cygnus.listener.StaminaStateChangeListener;
 import net.onelitefeather.cygnus.listener.game.GameFinishListener;
 import net.onelitefeather.cygnus.listener.game.GamePageListener;
 import net.onelitefeather.cygnus.listener.game.GamePreLaunchListener;
@@ -152,6 +154,7 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
         manager.addListener(
                 SlenderReviveEvent.class, new GameReviveListener(((GameMapProvider) this.mapProvider).getGameMap(), this.staminaService));
         manager.addListener(GamePreLaunchEvent.class, new GamePreLaunchListener(this.pageProvider::setMaxPageAmount));
+        manager.addListener(StaminaStateChangeEvent.class, new StaminaStateChangeListener());
         MinecraftServer.getPacketListenerManager().setPlayListener(ClientEntityActionPacket.class, CygnusEntityActionListener::listener);
     }
 

--- a/game/src/main/java/net/onelitefeather/cygnus/event/StaminaStateChangeEvent.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/event/StaminaStateChangeEvent.java
@@ -1,0 +1,47 @@
+package net.onelitefeather.cygnus.event;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.PlayerEvent;
+import net.onelitefeather.cygnus.stamina.StaminaBar;
+
+/**
+ * Called when the state of a StaminaBar changes.
+ *
+ * @author Joltra
+ * @version 1.0.0
+ * @since 1.0.0
+ **/
+@SuppressWarnings("java:S6206")
+public final class StaminaStateChangeEvent implements PlayerEvent {
+
+    private final Player player;
+    private final StaminaBar.State state;
+
+    /**
+     * Creates a new instance of the {@link StaminaStateChangeEvent}.
+     *
+     * @param player the player whose stamina state changed
+     * @param state the new state
+     */
+    public StaminaStateChangeEvent(Player player, StaminaBar.State state) {
+        this.player = player;
+        this.state = state;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Player getPlayer() {
+        return this.player;
+    }
+
+    /**
+     * Returns the new state of the stamina bar.
+     *
+     * @return the state
+     */
+    public StaminaBar.State getState() {
+        return state;
+    }
+}

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/StaminaStateChangeListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/StaminaStateChangeListener.java
@@ -1,0 +1,40 @@
+package net.onelitefeather.cygnus.listener;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Player;
+import net.minestom.server.utils.PacketSendingUtils;
+import net.onelitefeather.cygnus.event.StaminaStateChangeEvent;
+import net.onelitefeather.cygnus.stamina.StaminaBar;
+
+import java.util.function.Consumer;
+
+/**
+ * Listener for stamina state changes to handle packet broadcasting.
+ *
+ * @author Joltra
+ * @version 1.0.0
+ * @since 1.0.0
+ **/
+public final class StaminaStateChangeListener implements Consumer<StaminaStateChangeEvent> {
+
+    @Override
+    public void accept(StaminaStateChangeEvent event) {
+        Player player = event.getPlayer();
+        StaminaBar.State state = event.getState();
+
+        if (state == StaminaBar.State.DRAINING) {
+            PacketSendingUtils.broadcastPlayPacket(player.getMetadataPacket());
+            MinecraftServer.getConnectionManager().getOnlinePlayers()
+                    .stream().filter(p -> !p.getUuid().equals(player.getUuid())).forEach(player::updateNewViewer);
+            PacketSendingUtils.broadcastPlayPacket(player.getMetadataPacket());
+            return;
+        }
+
+        if (state == StaminaBar.State.REGENERATING) {
+            PacketSendingUtils.broadcastPlayPacket(player.getMetadataPacket());
+            MinecraftServer.getConnectionManager().getOnlinePlayers()
+                    .stream().filter(p -> !p.getUuid().equals(player.getUuid())).forEach(player::updateOldViewer);
+            PacketSendingUtils.broadcastPlayPacket(player.getMetadataPacket());
+        }
+    }
+}

--- a/game/src/main/java/net/onelitefeather/cygnus/stamina/SlenderBar.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/stamina/SlenderBar.java
@@ -1,18 +1,16 @@
 package net.onelitefeather.cygnus.stamina;
 
 import net.kyori.adventure.sound.Sound;
-import net.minestom.server.coordinate.Pos;
-import net.minestom.server.entity.Player;
 import net.minestom.server.entity.attribute.Attribute;
+import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.sound.SoundEvent;
 import net.onelitefeather.cygnus.common.Tags;
 import net.onelitefeather.cygnus.common.util.Helper;
+import net.onelitefeather.cygnus.event.StaminaStateChangeEvent;
 import net.onelitefeather.cygnus.player.CygnusPlayer;
-import org.jetbrains.annotations.Nullable;
 
 import java.time.temporal.ChronoUnit;
-import java.util.function.BiConsumer;
 
 /**
  * @author theEvilReaper
@@ -29,7 +27,6 @@ public non-sealed class SlenderBar extends StaminaBar implements SlenderBarHelpe
     private static final float TIME_STEP = 0.5f;
     private final String tileChar;
     private final int time;
-    private @Nullable BiConsumer<Player, State> accept;
     private double currentTime;
     private StaminaColors colorState;
 
@@ -39,10 +36,6 @@ public non-sealed class SlenderBar extends StaminaBar implements SlenderBarHelpe
         this.time = MAX_TIME;
         this.currentTime = time;
         this.colorState = StaminaColors.DRAINING;
-    }
-
-    public void setAccept(BiConsumer<Player, State> accept) {
-        this.accept = accept;
     }
 
     @Override
@@ -72,7 +65,7 @@ public non-sealed class SlenderBar extends StaminaBar implements SlenderBarHelpe
         state = State.REGENERATING;
         colorState = StaminaColors.REGENERATING;
         player.setTag(Tags.HIDDEN, Helper.ONE_ID);
-        this.accept.accept(player, state);
+        EventDispatcher.call(new StaminaStateChangeEvent(player, state));
         this.applyNightVision(player);
         player.getAttribute(Attribute.MOVEMENT_SPEED).setBaseValue(0.1f);
         player.sendSpringPackets();
@@ -104,7 +97,7 @@ public non-sealed class SlenderBar extends StaminaBar implements SlenderBarHelpe
                 player.sendSpringPackets();
                 player.setSprinting(false);
                 player.setBlockedSprinting(true);
-                this.accept.accept(player, State.DRAINING);
+                EventDispatcher.call(new StaminaStateChangeEvent(player, state));
             }
             case REGENERATING -> {
                 state = State.DRAINING;
@@ -116,7 +109,7 @@ public non-sealed class SlenderBar extends StaminaBar implements SlenderBarHelpe
                 player.sendSpringPackets();
                 player.setSprinting(false);
                 player.setBlockedSprinting(true);
-                this.accept.accept(player, State.DRAINING);
+                EventDispatcher.call(new StaminaStateChangeEvent(player, state));
             }
             case DRAINING -> {
                 state = State.REGENERATING;
@@ -127,7 +120,7 @@ public non-sealed class SlenderBar extends StaminaBar implements SlenderBarHelpe
                 player.getAttribute(Attribute.MOVEMENT_SPEED).setBaseValue(0.1f);
                 player.sendSpringPackets();
                 player.setBlockedSprinting(false);
-                this.accept.accept(player, State.REGENERATING);
+                EventDispatcher.call(new StaminaStateChangeEvent(player, state));
             }
         }
         return true;

--- a/game/src/main/java/net/onelitefeather/cygnus/stamina/StaminaService.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/stamina/StaminaService.java
@@ -1,8 +1,6 @@
 package net.onelitefeather.cygnus.stamina;
 
-import net.minestom.server.utils.PacketSendingUtils;
 import net.theevilreaper.xerus.api.team.Team;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.Player;
 import net.minestom.server.utils.validate.Check;
 import net.onelitefeather.cygnus.player.CygnusPlayer;
@@ -64,22 +62,6 @@ public final class StaminaService {
     public void createStaminaBars(Team team) {
         Check.argCondition(!staminaBars.isEmpty(), "Unable to load stamina bars twice");
         Check.argCondition(team.getPlayers().isEmpty(), "Can't add players from a team without teams");
-        ((SlenderBar) this.slenderBar).setAccept((player, state) -> {
-            if (state == StaminaBar.State.DRAINING) {
-                PacketSendingUtils.broadcastPlayPacket(player.getMetadataPacket());
-                MinecraftServer.getConnectionManager().getOnlinePlayers()
-                        .stream().filter(p -> !p.getUuid().equals(player.getUuid())).forEach(player::updateNewViewer);
-                PacketSendingUtils.broadcastPlayPacket(player.getMetadataPacket());
-                return;
-            }
-
-            if (state == StaminaBar.State.REGENERATING) {
-                PacketSendingUtils.broadcastPlayPacket(player.getMetadataPacket());
-                MinecraftServer.getConnectionManager().getOnlinePlayers()
-                        .stream().filter(p -> !p.getUuid().equals(player.getUuid())).forEach(player::updateOldViewer);
-                PacketSendingUtils.broadcastPlayPacket(player.getMetadataPacket());
-            }
-        });
         for (Player player : team.getPlayers()) {
             this.staminaBars.put(player.getUuid(), StaminaFactory.createFoodStamina((CygnusPlayer) player));
         }


### PR DESCRIPTION
## Proposed changes

The current `SlenderBar` state notifier relies on a `BiConsumer`, which adds unnecessary complexity and requires callers to cast to the concrete type. This pull request replaces it with a `StaminaChangeEvent` to decouple the notification logic.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)