### PR TITLE
rework: simplify build script definitions across modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,49 +1,35 @@
-.idea
+# Gradle & Kotlin
+.gradle/
+build/
+.kotlin/
 
-*.class
-*.log
-*.ctxt
-.mtj.tmp/
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-hs_err_pid*
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-.idea/**/contentModel.xml
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-.idea/**/gradle.xml
-.idea/**/libraries
-cmake-build-*/
-.idea/**/mongoSettings.xml
+# IntelliJ IDEA
+.idea/
 *.iws
+*.iml
+*.ipr
 out/
-.idea_modules/
-atlassian-ide-plugin.xml
-.idea/replstate.xml
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
-.idea/httpRequests
-.idea/caches/build_file_checksums.ser
-.gradle
-**/build/
-!src/**/build/
-gradle-app.setting
-!gradle-wrapper.jar
-.gradletasknamecache
-run/
+
+# Eclipse
+.apt_generated/
+.classpath
+.factorypath
+.project
+.settings/
+.springBeans
+.sts4-cache/
+bin/
+
+# NetBeans
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+# VS Code
+.vscode/
+
+# OS-spezifisch
+.DS_Store
+Thumbs.db

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,34 +1,3 @@
 plugins {
     alias(libs.plugins.cyclonedx)
 }
-subprojects {
-    apply(plugin = "java")
-    apply(plugin = "jacoco")
-
-    tasks {
-        getByName<JavaCompile>("compileJava") {
-            options.release.set(25)
-            options.encoding = "UTF-8"
-        }
-        getByName<JacocoReport>("jacocoTestReport") {
-            dependsOn(project.tasks.named("test"))
-            reports {
-                xml.required.set(true)
-            }
-        }
-        getByName<Test>("test") {
-            jvmArgs("-Dminestom.inside-test=true")
-            finalizedBy(project.tasks.named("jacocoTestReport"))
-            useJUnitPlatform()
-            testLogging {
-                events("passed", "skipped", "failed")
-            }
-        }
-
-        configure<JavaPluginExtension> {
-            toolchain {
-                languageVersion.set(JavaLanguageVersion.of(25))
-            }
-        }
-    }
-}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/cygnus.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cygnus.java-conventions.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    java
+    jacoco
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(25)
+    options.encoding = "UTF-8"
+}
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("-Dminestom.inside-test=true")
+    finalizedBy(tasks.matching { it.name == "jacocoTestReport" })
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}
+
+tasks.withType<JacocoReport>().configureEach {
+    dependsOn(tasks.matching { it.name == "test" })
+    reports {
+        xml.required.set(true)
+    }
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("cygnus.java-conventions")
     `java-library`
 }
 

--- a/game/build.gradle.kts
+++ b/game/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("cygnus.java-conventions")
     `maven-publish`
     alias(libs.plugins.shadow)
     application
@@ -31,22 +32,6 @@ dependencies {
 }
 
 tasks {
-    jacocoTestReport {
-        dependsOn(test)
-        reports {
-            xml.required.set(true)
-        }
-    }
-
-    test {
-        finalizedBy(project.tasks.jacocoTestReport)
-        useJUnitPlatform()
-        jvmArgs("-Dminestom.inside-test=true")
-        testLogging {
-            events("passed", "skipped", "failed")
-        }
-    }
-
     jar {
         archiveClassifier.set("unshaded")
         dependsOn("shadowJar")
@@ -56,12 +41,6 @@ tasks {
         archiveClassifier.set("")
         archiveFileName.set("cygnus.jar")
         mergeServiceFiles()
-    }
-}
-
-tasks {
-    jar {
-        dependsOn("shadowJar")
     }
 }
 

--- a/setup/build.gradle.kts
+++ b/setup/build.gradle.kts
@@ -1,6 +1,5 @@
-import org.gradle.kotlin.dsl.test
-
 plugins {
+    id("cygnus.java-conventions")
     `maven-publish`
     alias(libs.plugins.shadow)
     application
@@ -30,21 +29,6 @@ dependencies {
     testRuntimeOnly(libs.junit.engine)
 }
 tasks {
-    jacocoTestReport {
-        dependsOn(test)
-        reports {
-            xml.required.set(true)
-        }
-    }
-
-    test {
-        finalizedBy(project.tasks.jacocoTestReport)
-        useJUnitPlatform()
-        testLogging {
-            events("passed", "skipped", "failed")
-        }
-    }
-
     jar {
         archiveClassifier.set("unshaded")
         dependsOn("shadowJar")


### PR DESCRIPTION
## Proposed changes

The project uses a multi-module structure to separate different parts of the codebase. Several modules share identical build script configuration, leading to duplicated code and increased maintenance effort.

This pull request introduces a Gradle convention plugin to centralize common build configuration. The plugin can be applied to individual modules, reducing duplication and making future changes easier to maintain.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)