### PR TITLE
chore(setup): add dedicated class to store item ids

### DIFF
--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/data/GameData.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/data/GameData.java
@@ -11,6 +11,7 @@ import net.onelitefeather.cygnus.common.util.GsonHelper;
 import net.onelitefeather.cygnus.setup.inventory.view.InventoryMode;
 import net.onelitefeather.cygnus.setup.inventory.view.MapDataOverviewInventory;
 import net.onelitefeather.cygnus.setup.inventory.view.SurvivorViewInventory;
+import net.onelitefeather.cygnus.setup.item.SetupItemId;
 import net.onelitefeather.cygnus.setup.item.SetupItems;
 import net.onelitefeather.cygnus.setup.map.MapDataCategory;
 import net.onelitefeather.cygnus.setup.util.SetupMessages;
@@ -119,7 +120,7 @@ public class GameData extends InstanceSetupData {
      */
     @Override
     public void handleItemInteraction(Player player, byte tagValue) {
-        if (3 == tagValue) {
+        if (SetupItemId.PAGE == tagValue) {
             swapPageMode();
             if (hasPageMode()) {
                 player.sendMessage(SetupMessages.PAGE_MODE_ENABLED);
@@ -128,25 +129,25 @@ public class GameData extends InstanceSetupData {
             SetupItems.setPageItems(player);
             return;
         }
-        if (4 == tagValue) {
+        if (SetupItemId.LEAVE_PAGE == tagValue) {
             swapPageMode();
             player.sendMessage(SetupMessages.PAGE_MODE_DISABLED);
             SetupItems.setGameLayout(player);
             return;
         }
 
-        if (5 == tagValue) {
+        if (SetupItemId.SURVIVOR == tagValue) {
             this.swapSurvivorMode();
             SetupItems.setSurvivorSpawn(player);
             return;
         }
 
-        if (6 == tagValue) {
+        if (SetupItemId.SPAWNS == tagValue) {
             this.openInventory(InventoryTarget.SURVIVOR);
             return;
         }
 
-        if (7 == tagValue) {
+        if (SetupItemId.LEAVE_MODE == tagValue) {
             this.swapSurvivorMode();
             SetupItems.setGameLayout(player);
             return;

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/item/SetupItemId.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/item/SetupItemId.java
@@ -1,0 +1,24 @@
+package net.onelitefeather.cygnus.setup.item;
+
+/**
+ * Holds all item tag identifiers used during the setup process.
+ *
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 2.6.0
+ */
+public final class SetupItemId {
+
+    public static final byte MAP_SELECTION  = (byte) 0x00;
+    public static final byte SAVE_DATA      = (byte) 0x01;
+    public static final byte DATA           = (byte) 0x02;
+    public static final byte PAGE           = (byte) 0x03;
+    public static final byte LEAVE_PAGE     = (byte) 0x04;
+    public static final byte SURVIVOR       = (byte) 0x05;
+    public static final byte SPAWNS         = (byte) 0x06;
+    public static final byte LEAVE_MODE     = (byte) 0x07;
+
+    private SetupItemId() {
+        // Nothing to do here
+    }
+}

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/item/SetupItems.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/item/SetupItems.java
@@ -19,9 +19,8 @@ import net.theevilreaper.aves.hotbar.HotBarLayout;
 public final class SetupItems {
 
     public static final ItemStack DECORATION_PANE;
-    public static final byte ZERO_INDEX = (byte) 0x00;
-    public static final byte FOURTH_INDEX = (byte) 0x04;
-
+    public static final byte DEFAULT    = (byte) 0x00;
+    public static final byte SELECTION  = (byte) 0x04;
     private static final HotBarLayout selectionLayout;
     private static final HotBarLayout lobbySetupLayout;
     private static final HotBarLayout gameSetupLayout;
@@ -29,21 +28,26 @@ public final class SetupItems {
     private static final HotBarLayout survivorSpawnLayout;
 
     static {
-        DECORATION_PANE = ItemStack.builder(Material.BLACK_STAINED_GLASS_PANE).customName(Component.empty()).build();
-        selectionLayout = new HotBarLayout();
-        selectionLayout.set(FOURTH_INDEX, ItemStack.builder(Material.CHEST)
-                .customName(Component.text("Map selection", NamedTextColor.GREEN))
-                .set(Tags.ITEM_TAG, ZERO_INDEX)
-                .build()
-        );
+        DECORATION_PANE = ItemStack.builder(Material.BLACK_STAINED_GLASS_PANE)
+                .customName(Component.empty())
+                .build();
+
         ItemStack saveItem = ItemStack.builder(Material.BELL)
                 .customName(Component.text("Save data", NamedTextColor.RED))
-                .set(Tags.ITEM_TAG, (byte) 0x01)
+                .set(Tags.ITEM_TAG, SetupItemId.SAVE_DATA)
                 .build();
+
+        selectionLayout = new HotBarLayout();
+        selectionLayout.set(SELECTION, ItemStack.builder(Material.CHEST)
+                .customName(Component.text("Map selection", NamedTextColor.GREEN))
+                .set(Tags.ITEM_TAG, SetupItemId.MAP_SELECTION)
+                .build()
+        );
+
         lobbySetupLayout = new HotBarLayout();
         lobbySetupLayout.set(2, ItemStack.builder(Material.COMPASS)
                 .customName(Component.text("Data", NamedTextColor.AQUA))
-                .set(Tags.ITEM_TAG, (byte) 0x02)
+                .set(Tags.ITEM_TAG, SetupItemId.DATA)
                 .build()
         );
         lobbySetupLayout.set(6, saveItem);
@@ -51,17 +55,17 @@ public final class SetupItems {
         gameSetupLayout = new HotBarLayout();
         gameSetupLayout.set(1, ItemStack.builder(Material.COMPASS)
                 .customName(Component.text("Data", NamedTextColor.AQUA))
-                .set(Tags.ITEM_TAG, (byte) 0x02)
+                .set(Tags.ITEM_TAG, SetupItemId.DATA)
                 .build()
         );
         gameSetupLayout.set(3, ItemStack.builder(Material.PAPER)
                 .customName(Component.text("Page", NamedTextColor.AQUA))
-                .set(Tags.ITEM_TAG, (byte) 0x03)
+                .set(Tags.ITEM_TAG, SetupItemId.PAGE)
                 .build()
         );
         gameSetupLayout.set(5, ItemStack.builder(Material.MINECART)
                 .customName(Component.text("Survivor", NamedTextColor.YELLOW))
-                .set(Tags.ITEM_TAG, (byte) 0x05)
+                .set(Tags.ITEM_TAG, SetupItemId.SURVIVOR)
                 .build()
         );
         gameSetupLayout.set(7, saveItem);
@@ -69,20 +73,19 @@ public final class SetupItems {
         pageLayout = new HotBarLayout();
         pageLayout.set(4, ItemStack.builder(Material.BARRIER)
                 .customName(Component.text("Leave page mode", NamedTextColor.RED))
-                .set(Tags.ITEM_TAG, (byte) 0x04)
+                .set(Tags.ITEM_TAG, SetupItemId.LEAVE_PAGE)
                 .build()
         );
 
         survivorSpawnLayout = new HotBarLayout();
         survivorSpawnLayout.set(2, ItemStack.builder(Material.CHEST)
                 .customName(Component.text("Spawns", NamedTextColor.AQUA))
-                .set(Tags.ITEM_TAG, (byte) 0x06)
+                .set(Tags.ITEM_TAG, SetupItemId.SPAWNS)
                 .build()
         );
-        survivorSpawnLayout.set(6
-                , ItemStack.builder(Material.BARRIER)
+        survivorSpawnLayout.set(6, ItemStack.builder(Material.BARRIER)
                 .customName(Component.text("Leave mode", NamedTextColor.RED))
-                .set(Tags.ITEM_TAG, (byte) 0x07)
+                .set(Tags.ITEM_TAG, SetupItemId.LEAVE_MODE)
                 .build()
         );
     }
@@ -94,7 +97,7 @@ public final class SetupItems {
      */
     public static void setMapSelection(Player player) {
         selectionLayout.apply(player);
-        player.setHeldItemSlot(FOURTH_INDEX);
+        player.setHeldItemSlot(SELECTION);
     }
 
     /**
@@ -104,7 +107,7 @@ public final class SetupItems {
      */
     public static void setLobbyLayout(Player player) {
         lobbySetupLayout.apply(player);
-        player.setHeldItemSlot(ZERO_INDEX);
+        player.setHeldItemSlot(DEFAULT);
     }
 
     /**
@@ -114,7 +117,7 @@ public final class SetupItems {
      */
     public static void setGameLayout(Player player) {
         gameSetupLayout.apply(player);
-        player.setHeldItemSlot(FOURTH_INDEX);
+        player.setHeldItemSlot(SELECTION);
     }
 
     /**
@@ -124,7 +127,7 @@ public final class SetupItems {
      */
     public static void setSurvivorSpawn(Player player) {
         survivorSpawnLayout.apply(player);
-        player.setHeldItemSlot(ZERO_INDEX);
+        player.setHeldItemSlot(DEFAULT);
     }
 
     /**
@@ -134,10 +137,8 @@ public final class SetupItems {
      */
     public static void setPageItems(Player player) {
         pageLayout.apply(player);
-        player.setHeldItemSlot(ZERO_INDEX);
+        player.setHeldItemSlot(DEFAULT);
     }
 
-    private SetupItems() {
-        // Nothing to do here
-    }
+    private SetupItems() {}
 }

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/listener/SetupItemListener.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/listener/SetupItemListener.java
@@ -37,8 +37,8 @@ public final class SetupItemListener implements Consumer<PlayerUseItemEvent> {
             return;
         }
 
-        // Check if the given tag value is 0 which represents the item for the map selection
-        if (SetupItems.ZERO_INDEX == tagValue) {
+        // Check if the given tag value is 0 that represents the item for the map selection
+        if (SetupItems.DEFAULT == tagValue) {
             mapSetupInventory.open(player);
         }
 

--- a/setup/src/test/java/net/onelitefeather/cygnus/setup/item/SetupItemsTest.java
+++ b/setup/src/test/java/net/onelitefeather/cygnus/setup/item/SetupItemsTest.java
@@ -25,7 +25,7 @@ class SetupItemsTest {
 
         SetupItems.setMapSelection(player);
 
-        assertItem(player, SetupItems.FOURTH_INDEX, (byte) 0x00);
+        assertItem(player, SetupItems.SELECTION, (byte) 0x00);
 
         env.destroyInstance(instance, true);
     }


### PR DESCRIPTION
## Proposed changes

The setup relies on different IDs to determine which action a player performed based on the item they interacted with. Currently, these IDs are hardcoded throughout the implementation, resulting in the use of magic values.

This pull request introduces a dedicated class that defines these IDs as constants, improving readability and maintainability.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)