### PR TITLE
feat(setup): add default lore for fallback items

### DIFF
--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/item/SetupItems.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/item/SetupItems.java
@@ -6,13 +6,10 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.onelitefeather.cygnus.common.Tags;
-import net.onelitefeather.cygnus.setup.util.SetupMessages;
 import net.theevilreaper.aves.hotbar.HotBarLayout;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static net.onelitefeather.cygnus.setup.util.SetupMessages.SPACE_SEPARATOR;
+import static net.onelitefeather.cygnus.setup.util.SetupMessages.getLore;
 
 /**
  * The class holds the {@link ItemStack} references which have some functionality during a setup process from an map.
@@ -189,13 +186,5 @@ public final class SetupItems {
     }
 
     private SetupItems() {
-    }
-
-    private static List<Component> getLore(Component... components) {
-        List<Component> lore = new ArrayList<>();
-        lore.add(Component.empty());
-        lore.addAll(List.of(components));
-        lore.add(Component.empty());
-        return lore;
     }
 }

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/map/MapDataCategory.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/map/MapDataCategory.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
+import net.onelitefeather.cygnus.setup.util.SetupMessages;
 import net.onelitefeather.cygnus.setup.util.SetupTags;
 
 import java.util.EnumMap;
@@ -81,9 +82,12 @@ public enum MapDataCategory {
     public static ItemStack getDefaultItem(MapDataCategory category) {
         return DEFAULT_CACHE.computeIfAbsent(category, mapDataCategory ->
                 ItemStack.builder(mapDataCategory.getMaterial())
-                        .customName(Component.text(mapDataCategory.name, mapDataCategory.color))
-                        .set(SetupTags.MAP_DATA_CATEGORY_TAG, category)
-                        .build());
+                        .lore(SetupMessages.getLoreWith(SetupMessages.SPACE_SEPARATOR
+                                        .append(Component.text("Click to add new data", NamedTextColor.WHITE))
+                                ))
+                                .customName(Component.text(mapDataCategory.name, mapDataCategory.color))
+                                .set(SetupTags.MAP_DATA_CATEGORY_TAG, category)
+                                .build());
     }
 
     /**

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/map/MapDataCategory.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/map/MapDataCategory.java
@@ -82,7 +82,7 @@ public enum MapDataCategory {
     public static ItemStack getDefaultItem(MapDataCategory category) {
         return DEFAULT_CACHE.computeIfAbsent(category, mapDataCategory ->
                 ItemStack.builder(mapDataCategory.getMaterial())
-                        .lore(SetupMessages.getLoreWith(SetupMessages.SPACE_SEPARATOR
+                        .lore(SetupMessages.getLore(SetupMessages.SPACE_SEPARATOR
                                         .append(Component.text("Click to add new data", NamedTextColor.WHITE))
                                 ))
                                 .customName(Component.text(mapDataCategory.name, mapDataCategory.color))

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/util/SetupMessages.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/util/SetupMessages.java
@@ -9,10 +9,15 @@ import net.onelitefeather.cygnus.common.Messages;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * The class contains method and static constant values to handle specific messages during the setup
+ *
  * @author theEvilReaper
- * @version 1.2.1
+ * @version 1.3.0
  * @since 1.0.0
  */
 public final class SetupMessages {
@@ -87,6 +92,20 @@ public final class SetupMessages {
         PreProcess facePreProcess = Tag.preProcessParsed(face);
         TagResolver faceTag = TagResolver.builder().tag("face", (_, _) -> facePreProcess).build();
         return Messages.withMini("<red>You are looking in an invalid direction! <gray>(<gold><face><gray>)", faceTag);
+    }
 
+    /**
+     * Returns a list that contains the given components which some additional empty components
+     *
+     * @param components to add
+     * @return the list with the {@link Component}s
+     */
+    @Contract(value = "_ -> new", pure = true)
+    public static List<Component> getLore(@NotNull Component... components) {
+        List<Component> lore = new ArrayList<>();
+        lore.add(Component.empty());
+        lore.addAll(Arrays.asList(components));
+        lore.add(Component.empty());
+        return lore;
     }
 }


### PR DESCRIPTION
## Proposed changes

When no data is available for specific points, the setup falls back to default items. To improve clarity in these cases, this pull request introduces default lore definitions for these fallback items.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)