### PR TITLE
chore(setup): update bossbar title change

### DIFF
--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/data/GameData.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/data/GameData.java
@@ -1,6 +1,7 @@
 package net.onelitefeather.cygnus.setup.data;
 
 import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
@@ -83,6 +84,19 @@ public class GameData extends InstanceSetupData {
                 // Nothing to do here
             }
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateTitle() {
+        if (getMapBuilder().getName().equalsIgnoreCase("Map")) {
+            super.updateTitle();
+            return;
+        }
+        this.title = Component.text("Map: ").append(Component.text(getMapBuilder().getName(), MapDataCategory.NAME.getColor()));
+        super.updateTitle();
     }
 
     /**

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/data/GameData.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/data/GameData.java
@@ -91,7 +91,9 @@ public class GameData extends InstanceSetupData {
      */
     @Override
     public void updateTitle() {
+        System.out.println("TItle is " + (title == null));
         if (getMapBuilder().getName().equalsIgnoreCase("Map")) {
+            this.title = null;
             super.updateTitle();
             return;
         }
@@ -177,7 +179,10 @@ public class GameData extends InstanceSetupData {
     public void handleDataDelete(MapDataCategory category) {
         switch (category) {
             case SPAWN -> gameMapBuilder.spawn(null);
-            case NAME -> gameMapBuilder.name(null);
+            case NAME -> {
+                gameMapBuilder.name("Map");
+                this.updateTitle();
+            }
             case AUTHOR -> gameMapBuilder.builders("");
             case SLENDER -> gameMapBuilder.setSlenderSpawn(null);
             default -> throw new IllegalArgumentException("Unknown inventory category: " + category);

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/data/LobbyData.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/data/LobbyData.java
@@ -1,6 +1,7 @@
 package net.onelitefeather.cygnus.setup.data;
 
 import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
@@ -61,6 +62,18 @@ public final class LobbyData extends InstanceSetupData {
         this.viewInventory.invalidateDataLayout();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateTitle() {
+        if (getMapBuilder().getName().equalsIgnoreCase("Map")) {
+            super.updateTitle();
+            return;
+        }
+        this.title = Component.text("Map: ").append(Component.text(getMapBuilder().getName(), MapDataCategory.NAME.getColor()));
+        super.updateTitle();
+    }
 
     /**
      * {@inheritDoc}

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/data/LobbyData.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/data/LobbyData.java
@@ -68,6 +68,7 @@ public final class LobbyData extends InstanceSetupData {
     @Override
     public void updateTitle() {
         if (getMapBuilder().getName().equalsIgnoreCase("Map")) {
+            this.title = null;
             super.updateTitle();
             return;
         }
@@ -82,7 +83,10 @@ public final class LobbyData extends InstanceSetupData {
     public void handleDataDelete(MapDataCategory category) {
         switch (category) {
             case SPAWN -> mapBuilder.spawn(null);
-            case NAME -> mapBuilder.name(null);
+            case NAME -> {
+                mapBuilder.name("Map");
+                this.updateTitle();
+            }
             case AUTHOR -> mapBuilder.builders("");
             default -> throw new IllegalArgumentException("Unknown inventory category: " + category);
         }


### PR DESCRIPTION
## Proposed changes

Due to the rework of the setup system, the bossbar now only displays a static title. Originally, it was intended to indicate the currently active setup and the name of the map. This pull request fixes the bossbar title update behavior.

**Needs testing**

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)