### PR TITLE
feat(game): add ability to use a custom page model

### DIFF
--- a/common/src/main/java/net/onelitefeather/cygnus/common/page/PageCreator.java
+++ b/common/src/main/java/net/onelitefeather/cygnus/common/page/PageCreator.java
@@ -1,0 +1,52 @@
+package net.onelitefeather.cygnus.common.page;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.minestom.server.component.DataComponents;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Creates page items for the game.
+ * <p>
+ * When custom pages are enabled, a random item model is assigned to the page.
+ * The available models range from {@code page_0} up to {@code page_(MAX_CUSTOM_PAGE_ID - 1)}.
+ * If custom pages are disabled, a regular paper item is returned instead.
+ *
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 2.6.6
+ */
+public interface PageCreator {
+
+    /**
+     * Number of available custom page models.
+     */
+    int MAX_CUSTOM_PAGE_ID = 6;
+
+    /**
+     * Creates a page item with the given page number.
+     * <p>
+     * If custom pages are enabled, one of the available page models is chosen
+     * randomly. Otherwise, the returned item only contains its display name.
+     *
+     * @param pageCount the number displayed on the page
+     * @return the created page item
+     */
+    default ItemStack createPageItem(boolean customPage, int pageCount) {
+        ItemStack.Builder builder = ItemStack.builder(Material.PAPER)
+                .customName(Component.text("Page: " + pageCount));
+
+        if (!customPage) {
+            return builder.build();
+        }
+
+        int randomPage = ThreadLocalRandom.current().nextInt(MAX_CUSTOM_PAGE_ID);
+
+        return builder
+                .set(DataComponents.ITEM_MODEL, Key.key("cygnus", "page_" + randomPage).asString())
+                .build();
+    }
+}

--- a/common/src/main/java/net/onelitefeather/cygnus/common/page/PageEntity.java
+++ b/common/src/main/java/net/onelitefeather/cygnus/common/page/PageEntity.java
@@ -26,12 +26,13 @@ import java.util.concurrent.CompletableFuture;
  * The entity consists of a visual display and an interaction hitbox to improve pickup detection.
  *
  * @author theEvilReaper
- * @version 1.1.0
+ * @version 1.2.0
  * @since 1.0.0
  */
 @SuppressWarnings("java:S3252")
-public final class PageEntity extends Entity {
+public final class PageEntity extends Entity implements PageCreator{
 
+    private static final boolean CUSTOM_PAGES = Boolean.parseBoolean(System.getProperty("cygnus.custom_pages", "false"));
     private static final Vec HALF_BLOCK = new Vec(0, 0.5, 0);
     private static final long ADDITION_TIME = 1000L;
     private final Entity hitBox;
@@ -52,7 +53,7 @@ public final class PageEntity extends Entity {
         super(EntityType.ITEM_DISPLAY);
         this.setInstance(instance, spawnPos);
         this.hitBox = new Entity(EntityType.INTERACTION);
-        this.pageItem = ItemStack.builder(Material.PAPER).customName(Component.text("Page: " + pageCount)).build();
+        this.pageItem = createPageItem(CUSTOM_PAGES, pageCount);
         this.ttlTime = Helper.calculateOffsetTime(GameConfig.PAGE_TTL_TIME);
 
         ItemDisplayMeta itemDisplayMeta = (ItemDisplayMeta) this.getEntityMeta();

--- a/common/src/test/java/net/onelitefeather/cygnus/common/page/PageCreatorTest.java
+++ b/common/src/test/java/net/onelitefeather/cygnus/common/page/PageCreatorTest.java
@@ -1,0 +1,51 @@
+package net.onelitefeather.cygnus.common.page;
+
+import net.minestom.server.component.DataComponents;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import net.minestom.testing.Env;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.util.ClearSystemProperty;
+import org.junit.jupiter.api.util.SetSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MicrotusExtension.class)
+class PageCreatorTest {
+
+    private final PageCreator pageCreator = new PageCreator() {};
+
+    @AfterEach
+    @ClearSystemProperty(key = "cygnus.custom_pages")
+    void tearDown() {
+    }
+
+    @Test
+    @SetSystemProperty(key = "cygnus.custom_pages", value = "false")
+    void shouldCreateDefaultPageWhenCustomPagesAreDisabled(Env ignored) {
+        boolean useCustomPage = Boolean.parseBoolean(System.getProperty("cygnus.custom_pages"));
+        ItemStack page = pageCreator.createPageItem(useCustomPage, 5);
+
+        assertEquals(Material.PAPER, page.material());
+
+        assertTrue(page.has(DataComponents.ITEM_MODEL));
+        String model = page.get(DataComponents.ITEM_MODEL);
+        assertEquals("minecraft:paper", model);
+    }
+
+    @Test
+    @SetSystemProperty(key = "cygnus.custom_pages", value = "true")
+    void shouldAssignCustomModelWhenCustomPagesAreEnabled(Env ignored) {
+        boolean useCustomPage = Boolean.parseBoolean(System.getProperty("cygnus.custom_pages"));
+        ItemStack page = pageCreator.createPageItem(useCustomPage, 5);
+
+        assertTrue(page.has(DataComponents.ITEM_MODEL));
+        String model = page.get(DataComponents.ITEM_MODEL);
+
+        assertNotNull(model);
+        assertTrue(model.matches("cygnus:page_[0-5]"));
+    }
+}


### PR DESCRIPTION
## Proposed changes

This pull request adds the option to use a custom item model for pages instead of the default vanilla paper item. To enable this feature, the system property `cygnus.custom_pages` must be set to `true` (e.g. via a JVM start flag: `-Dcygnus.custom_pages=true`). By default, this property is set to `false`, so custom page models are disabled unless explicitly enabled.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)