### PR TITLE
fix(player): keep chunks visible when a player changes instance

### DIFF
--- a/common/src/main/java/net/onelitefeather/cygnus/common/player/InstanceSwitchChunkPlayer.java
+++ b/common/src/main/java/net/onelitefeather/cygnus/common/player/InstanceSwitchChunkPlayer.java
@@ -1,0 +1,137 @@
+package net.onelitefeather.cygnus.common.player;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.SendablePacket;
+import net.minestom.server.network.packet.server.play.UnloadChunkPacket;
+import net.minestom.server.network.player.GameProfile;
+import net.minestom.server.network.player.PlayerConnection;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A {@link Player} which keeps chunks from disappearing when it is moved to another instance.
+ *
+ * <p>Since 26.2 a client which processes an {@code UnloadChunkPacket} and the {@code ChunkDataPacket}
+ * of the same chunk within one frame renders that chunk invisible until it is unloaded and loaded
+ * again (<a href="https://bugs.mojang.com/browse/MC/issues/MC-310041">MC-310041</a>). An instance
+ * switch does exactly that for every chunk the old and the new view have in common, which is all of
+ * them when both instances are entered at the same position.</p>
+ *
+ * <p>Minestom fixes this in
+ * <a href="https://github.com/Minestom/Minestom/pull/3308">PR #3308</a> by not sending the unload
+ * packet for those chunks. The fix sits in {@code Player#spawnPlayer}, which is private, so it
+ * cannot be overridden — but the unload packets travel through {@link #sendPacket(SendablePacket)},
+ * which can. This class therefore drops the same packets the upstream fix never sends: while an
+ * instance switch is in flight, an unload for a chunk inside the target view is discarded.</p>
+ *
+ * <p>The {@code PlayerChunkUnloadEvent} is still dispatched for those chunks — the server side of
+ * the unload is untouched, exactly as upstream. What this cannot reproduce is the second half of the
+ * fix: chunks the client holds around its <em>old</em> position which fall outside the new view are
+ * not unloaded, because the unpatched server never sends an unload for them in the first place.
+ * Those are the chunks upstream describes as briefly visible after the switch.</p>
+ *
+ * <p><b>Remove this class</b> once the server runs a Minestom build that contains PR #3308 — as of
+ * {@code 2026.07.22-26.2} the newest published build predates the merge. Upstream itself intends to
+ * revert the workaround for 26.3, where the client bug is fixed.</p>
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 2.6.7
+ */
+public abstract class InstanceSwitchChunkPlayer extends Player {
+
+    private volatile @Nullable TargetView targetView;
+
+    /**
+     * Creates a new player for the given connection.
+     *
+     * @param playerConnection the connection of the player
+     * @param gameProfile      the profile of the player
+     */
+    protected InstanceSwitchChunkPlayer(PlayerConnection playerConnection, GameProfile gameProfile) {
+        super(playerConnection, gameProfile);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Remembers which chunks the player is about to see, so {@link #sendPacket(SendablePacket)}
+     * can tell the unload packets of the switch apart from the ones a moving player produces.</p>
+     */
+    @Override
+    public CompletableFuture<Void> setInstance(Instance instance, Pos spawnPosition) {
+        this.targetView = new TargetView(
+                spawnPosition.chunkX(),
+                spawnPosition.chunkZ(),
+                targetViewDistance(instance)
+        );
+
+        CompletableFuture<Void> future;
+        try {
+            future = super.setInstance(instance, spawnPosition);
+        } catch (RuntimeException exception) {
+            // A rejected switch never sends a packet, so the filter has to go right back off
+            this.targetView = null;
+            throw exception;
+        }
+
+        // The original future is returned rather than the one whenComplete creates, because its
+        // join() carries the deadlock guard Minestom puts on it
+        future.whenComplete((unused, throwable) -> this.targetView = null);
+        return future;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Drops the unload packets of an ongoing instance switch for chunks the player keeps seeing.</p>
+     */
+    @Override
+    public void sendPacket(SendablePacket packet) {
+        TargetView view = this.targetView;
+        if (view != null
+                && packet instanceof UnloadChunkPacket unloadChunkPacket
+                && view.contains(unloadChunkPacket.chunkX(), unloadChunkPacket.chunkZ())) {
+            return;
+        }
+        super.sendPacket(packet);
+    }
+
+    /**
+     * Returns the view distance the player will have in the given instance.
+     *
+     * <p>This is what {@code Player#effectiveViewDistance} computes, except that it asks the
+     * instance the player is moving to instead of the one it is still in.</p>
+     *
+     * @param instance the instance the player is moving to
+     * @return the effective chunk view distance in that instance
+     */
+    private int targetViewDistance(Instance instance) {
+        return Math.min(getSettings().viewDistance(), instance.viewDistance()) + 1;
+    }
+
+    /**
+     * The chunk area a player is about to see, as a centre and a radius in chunks.
+     *
+     * @param chunkX       the chunk x of the target position
+     * @param chunkZ       the chunk z of the target position
+     * @param viewDistance the effective view distance in the target instance
+     */
+    private record TargetView(int chunkX, int chunkZ, int viewDistance) {
+
+        /**
+         * Returns whether the given chunk lies inside this view.
+         *
+         * @param x the chunk x to check
+         * @param z the chunk z to check
+         * @return true if the chunk is inside the view
+         */
+        boolean contains(int x, int z) {
+            return Math.abs(x - this.chunkX) <= this.viewDistance
+                    && Math.abs(z - this.chunkZ) <= this.viewDistance;
+        }
+    }
+}

--- a/common/src/test/java/net/onelitefeather/cygnus/common/player/InstanceSwitchChunkPlayerIntegrationTest.java
+++ b/common/src/test/java/net/onelitefeather/cygnus/common/player/InstanceSwitchChunkPlayerIntegrationTest.java
@@ -1,0 +1,163 @@
+package net.onelitefeather.cygnus.common.player;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.PlayerProvider;
+import net.minestom.server.network.packet.server.play.UnloadChunkPacket;
+import net.minestom.server.network.player.GameProfile;
+import net.minestom.server.network.player.PlayerConnection;
+import net.minestom.testing.Collector;
+import net.minestom.testing.Env;
+import net.minestom.testing.TestConnection;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the workaround for the 26.2 client bug that makes chunks invisible after an instance
+ * switch: unload packets for chunks the player keeps seeing must not reach the client, while every
+ * other unload must.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 2.6.7
+ */
+@ExtendWith(MicrotusExtension.class)
+class InstanceSwitchChunkPlayerIntegrationTest {
+
+    private static final Pos SPAWN = new Pos(0, 42, 0);
+
+    @BeforeAll
+    static void setUp(Env env) {
+        env.process().connection().setPlayerProvider(new TestPlayerProvider());
+    }
+
+    @Test
+    void testSwitchToSamePositionSendsNoUnload(Env env) {
+        Instance source = env.createFlatInstance();
+        Instance target = env.createFlatInstance();
+
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(source, SPAWN);
+        assertInstanceOf(InstanceSwitchChunkPlayer.class, player);
+
+        Collector<UnloadChunkPacket> unloads = connection.trackIncoming(UnloadChunkPacket.class);
+        player.setInstance(target, SPAWN).join();
+
+        unloads.assertCount(0);
+
+        env.destroyInstance(target, true);
+        env.destroyInstance(source, true);
+    }
+
+    @Test
+    void testPlainPlayerStillReceivesTheUnloads(Env env) {
+        // The counterpart of the test above: without the override the client is told to unload the
+        // very chunks it is about to be sent again, which is what makes them invisible
+        var connectionManager = env.process().connection();
+        connectionManager.setPlayerProvider(Player::new);
+        try {
+            Instance source = env.createFlatInstance();
+            Instance target = env.createFlatInstance();
+
+            TestConnection connection = env.createConnection();
+            Player player = connection.connect(source, SPAWN);
+
+            Collector<UnloadChunkPacket> unloads = connection.trackIncoming(UnloadChunkPacket.class);
+            player.setInstance(target, SPAWN).join();
+
+            assertFalse(unloads.collect().isEmpty(), "An unpatched player unloads the shared chunks");
+
+            env.destroyInstance(target, true);
+            env.destroyInstance(source, true);
+        } finally {
+            connectionManager.setPlayerProvider(new TestPlayerProvider());
+        }
+    }
+
+    @Test
+    void testShrinkingViewStillUnloadsTheOuterChunks(Env env) {
+        Instance source = env.createFlatInstance();
+        source.viewDistance(8);
+        Instance target = env.createFlatInstance();
+        target.viewDistance(3);
+
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(source, SPAWN);
+
+        Collector<UnloadChunkPacket> unloads = connection.trackIncoming(UnloadChunkPacket.class);
+        player.setInstance(target, SPAWN).join();
+
+        List<UnloadChunkPacket> received = unloads.collect();
+        assertFalse(received.isEmpty(), "Chunks outside the target view still have to be unloaded");
+
+        int targetViewDistance = player.effectiveViewDistance();
+        assertTrue(
+                received.stream().noneMatch(packet -> isInView(packet, targetViewDistance)),
+                "No chunk inside the target view may be unloaded"
+        );
+
+        env.destroyInstance(target, true);
+        env.destroyInstance(source, true);
+    }
+
+    @Test
+    void testFilterIsLiftedAfterTheSwitch(Env env) {
+        Instance source = env.createFlatInstance();
+        Instance target = env.createFlatInstance();
+
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(source, SPAWN);
+        player.setInstance(target, SPAWN).join();
+
+        Collector<UnloadChunkPacket> unloads = connection.trackIncoming(UnloadChunkPacket.class);
+        player.sendPacket(new UnloadChunkPacket(SPAWN.chunkX(), SPAWN.chunkZ()));
+
+        unloads.assertCount(1);
+
+        env.destroyInstance(target, true);
+        env.destroyInstance(source, true);
+    }
+
+    /**
+     * Returns whether the chunk of the given packet lies within the view around {@link #SPAWN}.
+     *
+     * @param packet       the unload packet to check
+     * @param viewDistance the view distance in chunks
+     * @return true if the chunk is inside the view
+     */
+    private static boolean isInView(UnloadChunkPacket packet, int viewDistance) {
+        return Math.abs(packet.chunkX() - SPAWN.chunkX()) <= viewDistance
+                && Math.abs(packet.chunkZ() - SPAWN.chunkZ()) <= viewDistance;
+    }
+
+    /**
+     * Provides the minimal {@link InstanceSwitchChunkPlayer} the test connects with.
+     */
+    private static final class TestPlayerProvider implements PlayerProvider {
+
+        @Override
+        public Player createPlayer(PlayerConnection connection, GameProfile gameProfile) {
+            return new TestPlayer(connection, gameProfile);
+        }
+    }
+
+    /**
+     * A player which adds nothing to {@link InstanceSwitchChunkPlayer}, so the test observes the
+     * chunk filtering of the base class and nothing else.
+     */
+    private static final class TestPlayer extends InstanceSwitchChunkPlayer {
+
+        private TestPlayer(PlayerConnection playerConnection, GameProfile gameProfile) {
+            super(playerConnection, gameProfile);
+        }
+    }
+}

--- a/game/src/main/java/net/onelitefeather/cygnus/player/CygnusPlayer.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/player/CygnusPlayer.java
@@ -8,9 +8,10 @@ import net.minestom.server.entity.attribute.AttributeOperation;
 import net.minestom.server.network.packet.server.play.EntityAttributesPacket;
 import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.network.player.PlayerConnection;
+import net.onelitefeather.cygnus.common.player.InstanceSwitchChunkPlayer;
 
 @SuppressWarnings("java:S3252")
-public final class CygnusPlayer extends Player {
+public final class CygnusPlayer extends InstanceSwitchChunkPlayer {
 
     private static final AttributeModifier SPEED_MODIFIER_SPRINTING =
             new AttributeModifier(Key.key("minecraft:sprinting"), 0.25, AttributeOperation.ADD_MULTIPLIED_TOTAL);

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/player/SetupPlayer.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/player/SetupPlayer.java
@@ -4,6 +4,7 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.network.player.PlayerConnection;
+import net.onelitefeather.cygnus.common.player.InstanceSwitchChunkPlayer;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -13,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
  * @version 1.0.0
  * @since 2.0.0
  */
-public final class SetupPlayer extends Player {
+public final class SetupPlayer extends InstanceSwitchChunkPlayer {
 
     private @Nullable Point survivorToDelete;
     private @Nullable Point pageToDelete;


### PR DESCRIPTION
Works around the 26.2 client bug that makes chunks disappear when a player is moved to another instance — the lobby to arena switch in Cygnus.

## References

| | |
| --- | --- |
| Upstream fix | [Minestom/Minestom#3308 — Fix chunks disappearing when switching instances](https://github.com/Minestom/Minestom/pull/3308) (merged 2026-08-02, not in any published build yet) |
| Upstream issue | [Minestom/Minestom#3307 — Chunks disappear when switching instances](https://github.com/Minestom/Minestom/issues/3307) |
| Client bug | [MC-310041](https://bugs.mojang.com/browse/MC/issues/MC-310041) (fixed client-side in 26.3-snapshot5) |

This PR reproduces the effect of Minestom#3308 from outside the class, because the build we run predates it. It goes away when we move to a build that contains it.

## The bug

Since 26.2 a client that processes an `UnloadChunkPacket` and the `ChunkDataPacket` of the same chunk within one frame renders that chunk invisible until it is unloaded and loaded again ([MC-310041](https://bugs.mojang.com/browse/MC/issues/MC-310041)). An instance switch does exactly that for every chunk the old and the new view have in common — which is all of them when both instances are entered at the same position.

Minestom fixes this in [PR #3308](https://github.com/Minestom/Minestom/pull/3308) by not sending the unload packet for those chunks. It was merged 2026-08-02; the newest published build, `2026.07.22-26.2`, predates it.

## The approach

The upstream fix sits in `Player#spawnPlayer`, which is `private` and cannot be overridden. But the unload packets travel through `sendPacket(SendablePacket)`, which is public and not final. `InstanceSwitchChunkPlayer` drops the same packets the upstream fix never sends: while a switch is in flight, an unload for a chunk inside the target view is discarded. `CygnusPlayer` and `SetupPlayer` extend it.

The target view distance is taken from the instance being entered, not the one being left — the same correction PR #3308 makes to `effectiveViewDistance`.

`PlayerChunkUnloadEvent` is still dispatched for those chunks, exactly as upstream. The server-side unload is untouched.

## What it cannot do

The other half of the upstream fix: chunks the client holds around its **old** position which fall outside the new view are not unloaded, because the unpatched server never sends an unload for them to begin with — and you can only filter what is sent. Those are the chunks upstream describes as briefly visible after the switch. Irrelevant for Cygnus, where lobby and arena are entered at the same point.

## Tests

- switch to the same position sends no unload
- **the counterpart**: the same switch with a plain `Player` does receive unloads — so the test measures the workaround working, not an empty set
- a shrinking view distance still unloads the outer ring, and nothing inside the target view
- an `UnloadChunkPacket` passes again once the switch is over, so the filter cannot stick

`./gradlew build` green.

## Lifetime

Temporary. Remove `InstanceSwitchChunkPlayer` once the server runs a Minestom build containing PR #3308 — upstream intends to revert the workaround for 26.3, where the client bug is fixed. The class javadoc says so as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
