### PR TITLE
chore(logging): bind SLF4J so the services actually log

### DIFF
--- a/game/build.gradle.kts
+++ b/game/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
     implementation(libs.aves)
     implementation(libs.xerus)
 
+    // SLF4J needs a binding at runtime; without one it falls back to NOP and the
+    // server logs nothing at all.
+    runtimeOnly(libs.slf4j.simple)
+
     //CloudNet
     implementation(platform(libs.cloudnet.bom))
     implementation(libs.bundles.cloudnet)

--- a/game/src/main/resources/simplelogger.properties
+++ b/game/src/main/resources/simplelogger.properties
@@ -1,0 +1,9 @@
+# slf4j-simple writes to stderr without a timestamp by default, which is not enough to
+# investigate anything after the fact. Output goes to stdout so it keeps its order relative to
+# everything else the process prints, which is what CloudNet captures.
+org.slf4j.simpleLogger.logFile=System.out
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS
+org.slf4j.simpleLogger.showThreadName=true
+org.slf4j.simpleLogger.showShortLogName=true

--- a/game/src/test/java/net/onelitefeather/cygnus/logging/LoggingBindingTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/logging/LoggingBindingTest.java
@@ -1,0 +1,31 @@
+package net.onelitefeather.cygnus.logging;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that this module ships an SLF4J binding.
+ *
+ * <p>SLF4J without a provider does not fail — it prints a warning once and discards every message
+ * from then on, which looks exactly like a server that has nothing to say. The only way that
+ * regression announces itself is a test that asks.</p>
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 2.6.7
+ */
+class LoggingBindingTest {
+
+    @Test
+    void testALoggerIsBound() {
+        Logger logger = LoggerFactory.getLogger(LoggingBindingTest.class);
+
+        assertFalse(logger instanceof NOPLogger, "No SLF4J provider on the runtime classpath");
+        assertTrue(logger.isInfoEnabled(), "Info has to reach the log, or the server runs blind");
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ dependencyResolutionManagement {
 
             library("aonyx.bom", "net.onelitefeather", "aonyx-bom").versionRef("aonyx")
             library("slf4j.api", "org.slf4j", "slf4j-api").versionRef("slf4j")
+            library("slf4j.simple", "org.slf4j", "slf4j-simple").versionRef("slf4j")
             library("guava", "com.google.guava", "guava").versionRef("guava")
             library("luckperms.api", "net.luckperms", "api").versionRef("luckperms")
             library("luckperms.minestom.loader", "net.luckperms", "minestom-loader").versionRef("luckperms-minestom-loader")

--- a/setup/build.gradle.kts
+++ b/setup/build.gradle.kts
@@ -20,6 +20,10 @@ dependencies {
     implementation(libs.pica)
     implementation(libs.guira)
 
+    // SLF4J needs a binding at runtime; without one it falls back to NOP and the
+    // server logs nothing at all.
+    runtimeOnly(libs.slf4j.simple)
+
     //LuckPerms
     implementation(libs.guava)
     compileOnly(libs.luckperms.api) {

--- a/setup/src/main/resources/simplelogger.properties
+++ b/setup/src/main/resources/simplelogger.properties
@@ -1,0 +1,9 @@
+# slf4j-simple writes to stderr without a timestamp by default, which is not enough to
+# investigate anything after the fact. Output goes to stdout so it keeps its order relative to
+# everything else the process prints, which is what CloudNet captures.
+org.slf4j.simpleLogger.logFile=System.out
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS
+org.slf4j.simpleLogger.showThreadName=true
+org.slf4j.simpleLogger.showShortLogName=true

--- a/setup/src/test/java/net/onelitefeather/cygnus/setup/logging/LoggingBindingTest.java
+++ b/setup/src/test/java/net/onelitefeather/cygnus/setup/logging/LoggingBindingTest.java
@@ -1,0 +1,31 @@
+package net.onelitefeather.cygnus.setup.logging;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that this module ships an SLF4J binding.
+ *
+ * <p>SLF4J without a provider does not fail — it prints a warning once and discards every message
+ * from then on, which looks exactly like a server that has nothing to say. The only way that
+ * regression announces itself is a test that asks.</p>
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 2.6.7
+ */
+class LoggingBindingTest {
+
+    @Test
+    void testALoggerIsBound() {
+        Logger logger = LoggerFactory.getLogger(LoggingBindingTest.class);
+
+        assertFalse(logger instanceof NOPLogger, "No SLF4J provider on the runtime classpath");
+        assertTrue(logger.isInfoEnabled(), "Info has to reach the log, or the server runs blind");
+    }
+}


### PR DESCRIPTION
Both runnable modules depend on `slf4j-api` but never put a provider on the runtime classpath.

## Why this is not cosmetic

SLF4J does not fail when no binding is present. It prints one warning and then discards every message:

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
```

After that a running server is indistinguishable from a silent one. Every log statement in this project — startup, listeners, `ExceptionManager` output — went nowhere. This surfaced while running the setup server from `gradle run`: no output at all beyond that warning.

## What this adds

- `slf4j-simple` as `runtimeOnly` for the game and the setup module
- a `simplelogger.properties` per module

The defaults of slf4j-simple are stderr and no timestamp, which is not enough to investigate anything after the fact. Output now carries a timestamp and a thread name and goes to stdout, so it keeps its order relative to everything else the process prints — which is what CloudNet captures per service.

```properties
org.slf4j.simpleLogger.logFile=System.out
org.slf4j.simpleLogger.defaultLogLevel=info
org.slf4j.simpleLogger.showDateTime=true
org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS
org.slf4j.simpleLogger.showThreadName=true
org.slf4j.simpleLogger.showShortLogName=true
```

## Why slf4j-simple

Deliberately minimal: one jar, console only, no rolling files, no XML, configurable through the properties file or system properties. A CloudNet service has its output captured per service, so file handling inside the process buys nothing. If the services ever need to write log files themselves, this is the single place to swap in logback.

## Tests

`LoggingBindingTest` per module asserts that the bound logger is not a `NOPLogger` and that info actually reaches the log. A missing provider is exactly the kind of regression that stays quiet, so it needs a test that asks out loud.

Verified by counter-check: with the `runtimeOnly` line removed the test fails (`No SLF4J provider on the runtime classpath`) rather than passing vacuously.

`./gradlew build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)