### PR TITLE
feat(game): add mannequin entity

### DIFF
--- a/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
@@ -33,8 +33,6 @@ import net.minestom.server.listener.EntityActionListener;
 import net.minestom.server.network.packet.client.play.ClientEntityActionPacket;
 import net.onelitefeather.cygnus.ambient.AmbientProvider;
 import net.onelitefeather.cygnus.command.StartCommand;
-import net.onelitefeather.cygnus.command.SpawnMannequinCommand;
-import net.onelitefeather.cygnus.command.TriggerJumpscareCommand;
 import net.onelitefeather.cygnus.common.ListenerHandling;
 import net.onelitefeather.cygnus.common.config.GameConfig;
 import net.onelitefeather.cygnus.common.config.GameConfigReader;
@@ -123,8 +121,6 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
     private void initCommands() {
         var manager = MinecraftServer.getCommandManager();
         manager.register(new StartCommand(this.linearPhaseSeries));
-        manager.register(new SpawnMannequinCommand(this.jumpscareManager));
-        manager.register(new TriggerJumpscareCommand(this.jumpscareManager));
     }
 
 

--- a/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
@@ -33,6 +33,8 @@ import net.minestom.server.listener.EntityActionListener;
 import net.minestom.server.network.packet.client.play.ClientEntityActionPacket;
 import net.onelitefeather.cygnus.ambient.AmbientProvider;
 import net.onelitefeather.cygnus.command.StartCommand;
+import net.onelitefeather.cygnus.command.SpawnMannequinCommand;
+import net.onelitefeather.cygnus.command.TriggerJumpscareCommand;
 import net.onelitefeather.cygnus.common.ListenerHandling;
 import net.onelitefeather.cygnus.common.config.GameConfig;
 import net.onelitefeather.cygnus.common.config.GameConfigReader;
@@ -42,6 +44,7 @@ import net.onelitefeather.cygnus.common.page.event.PageEvent;
 import net.onelitefeather.cygnus.event.GameFinishEvent;
 import net.onelitefeather.cygnus.event.SlenderReviveEvent;
 import net.onelitefeather.cygnus.event.StaminaStateChangeEvent;
+import net.onelitefeather.cygnus.jumpscare.JumpScareManager;
 import net.onelitefeather.cygnus.listener.PlayerChatListener;
 import net.onelitefeather.cygnus.listener.PlayerDeathListener;
 import net.onelitefeather.cygnus.listener.PlayerLoginListener;
@@ -92,12 +95,14 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
     private final GameView view;
     private final AbstractMapProvider mapProvider;
     private final GameConfig gameConfig;
+    private final JumpScareManager jumpscareManager;
 
     public Cygnus() {
         Path path = Paths.get("");
         this.teamService = TeamService.of();
         this.linearPhaseSeries = new LinearPhaseSeries<>("game");
         this.staminaService = new StaminaService();
+        this.jumpscareManager = new JumpScareManager();
         this.gameConfig = new GameConfigReader(path).getConfig();
         MinecraftServer.getConnectionManager().setPlayerProvider(CygnusPlayer::new);
         this.pageProvider = new PageProvider();
@@ -118,7 +123,10 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
     private void initCommands() {
         var manager = MinecraftServer.getCommandManager();
         manager.register(new StartCommand(this.linearPhaseSeries));
+        manager.register(new SpawnMannequinCommand(this.jumpscareManager));
+        manager.register(new TriggerJumpscareCommand(this.jumpscareManager));
     }
+
 
     private void initListener() {
         Supplier<Phase> phaseSupplier = this.linearPhaseSeries::getCurrentPhase;
@@ -152,7 +160,7 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
         handler.addListener(PlayerUseItemEvent.class, new SlenderItemListener(trigger));
         handler.addListener(GameFinishEvent.class, new GameFinishListener());
         handler.addListener(GameStartEvent.class, new GameStartListener(this.teamService, this.ambientProvider, this.staminaService, this.pageProvider));
-        handler.addListener(PlayerDeathEvent.class, new PlayerDeathListener(phaseSupplier, this.teamService));
+        handler.addListener(PlayerDeathEvent.class, new PlayerDeathListener(phaseSupplier, this.teamService, this.jumpscareManager));
         handler.addListener(PlayerEntityInteractEvent.class, new PlayerPageInteractListener(this.pageProvider));
         handler.addListener(PageEvent.class, new GamePageListener(this.pageProvider));
         handler.addListener(PlayerStartSprintingEvent.class, new PlayerStartSprintingListener(this.staminaService::getFoodBar));
@@ -183,7 +191,7 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
         LobbyPhase lobbyPhase = new LobbyPhase(this.gameConfig);
         this.linearPhaseSeries.add(lobbyPhase);
         this.linearPhaseSeries.add(new WaitingPhase(this.view, instanceSwitch, teamInitializer));
-        this.linearPhaseSeries.add(new GamePhase(this.view, this::finishGame, this.gameConfig.gameTime()));
+        this.linearPhaseSeries.add(new GamePhase(this.view, this::finishGame, this.gameConfig.gameTime(), this.jumpscareManager));
         this.linearPhaseSeries.add(new RestartPhase());
     }
 
@@ -191,6 +199,7 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
         this.pageProvider.cleanUp();
         this.staminaService.cleanUp();
         this.ambientProvider.stopTask();
+        this.jumpscareManager.cleanUp();
         MinecraftServer.getPacketListenerManager().setPlayListener(ClientEntityActionPacket.class, EntityActionListener::listener);
     }
 

--- a/game/src/main/java/net/onelitefeather/cygnus/entity/DeadPlayerMannequin.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/entity/DeadPlayerMannequin.java
@@ -1,0 +1,152 @@
+package net.onelitefeather.cygnus.entity;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.EntityPose;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.entity.EquipmentSlot;
+import net.minestom.server.entity.LivingEntity;
+import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerSkin;
+import net.minestom.server.entity.metadata.avatar.MannequinMeta;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import net.minestom.server.network.packet.server.play.ParticlePacket;
+import net.minestom.server.network.packet.server.play.SpawnEntityPacket;
+import net.minestom.server.network.player.ResolvableProfile;
+import net.minestom.server.particle.Particle;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Custom mannequin entity representing a deceased survivor player.
+ *
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 2.7.0
+ */
+public class DeadPlayerMannequin extends LivingEntity {
+
+    private final UUID originalPlayerUuid;
+    private final @Nullable PlayerSkin skin;
+    private long ticksAlive = 0;
+    private boolean decayed = false;
+
+    /**
+     * Creates a sleeping corpse impersonating the given player. Call {@link #setInstance} on
+     * the result to actually spawn it.
+     *
+     * @param player the player this corpse represents
+     */
+    public static DeadPlayerMannequin sleeping(Player player) {
+        return sleeping(player.getUuid(), player.getSkin());
+    }
+
+    /**
+     * Creates a sleeping corpse impersonating a player identity. Call {@link #setInstance} on
+     * the result to actually spawn it.
+     *
+     * @param originalPlayerUuid the UUID of the player this corpse represents
+     * @param skin               the skin to render the corpse with, or null for the default skin
+     */
+    public static DeadPlayerMannequin sleeping(UUID originalPlayerUuid, @Nullable PlayerSkin skin) {
+        return new DeadPlayerMannequin(originalPlayerUuid, skin, EntityPose.SLEEPING);
+    }
+
+    /**
+     * Creates a standing, packet-only jumpscare phantom for a player identity. Never call
+     * {@link #setInstance} on the result, it only exists as raw packets sent to one victim.
+     *
+     * @param originalPlayerUuid the UUID of the player this phantom impersonates
+     * @param skin               the skin to render the phantom with, or null for the default skin
+     * @param position           the position/rotation to spawn the phantom at
+     */
+    public static DeadPlayerMannequin standing(UUID originalPlayerUuid, @Nullable PlayerSkin skin, Pos position) {
+        DeadPlayerMannequin phantom = new DeadPlayerMannequin(originalPlayerUuid, skin, EntityPose.STANDING);
+        phantom.setPacketPosition(position);
+        return phantom;
+    }
+
+    /**
+     * Creates a new entity with the given values.
+     *
+     * @param originalPlayerUuid of the player
+     * @param skin               of the player
+     * @param initialPose        for the entity
+     */
+    private DeadPlayerMannequin(UUID originalPlayerUuid, @Nullable PlayerSkin skin, EntityPose initialPose) {
+        super(EntityType.MANNEQUIN);
+        this.originalPlayerUuid = originalPlayerUuid;
+        this.skin = skin;
+
+        setNoGravity(true);
+        setHasPhysics(false);
+        setPose(initialPose);
+
+        if (getEntityMeta() instanceof MannequinMeta mannequinMeta) {
+            mannequinMeta.setDescription(null);
+            mannequinMeta.setImmovable(true);
+            mannequinMeta.setCapeEnabled(false);
+            if (skin != null) {
+                mannequinMeta.setProfile(new ResolvableProfile(skin));
+            }
+        }
+    }
+
+    @Override
+    public void update(long time) {
+        if (getInstance() == null || isRemoved()) return;
+
+        ticksAlive++;
+
+        // Decay logic: after 2 minutes (2400 ticks), swap head to skeleton skull
+        if (!decayed && ticksAlive >= 2400) {
+            decayed = true;
+            setEquipment(EquipmentSlot.HELMET, ItemStack.of(Material.SKELETON_SKULL));
+        }
+
+        // Atmosphere particles every 5 seconds (100 ticks) centered over the body
+        if (ticksAlive % 100 == 0) {
+            Pos pos = getPosition();
+            getInstance().sendGroupedPacket(
+                    new ParticlePacket(Particle.SPORE_BLOSSOM_AIR, true, false, pos.x(), pos.y() + 0.3, pos.z(), 0.4f, 0.2f, 0.4f, 0.01f, 15)
+            );
+        }
+    }
+
+    /**
+     * Sets the position/rotation for a mannequin that is never added to an instance.
+     *
+     * @param pos the position/rotation to spawn the mannequin at
+     */
+    public void setPacketPosition(Pos pos) {
+        setPositionInternal(pos, pos.yaw());
+    }
+
+    /**
+     * Builds the spawn packet for a mannequin that is never added to an instance.
+     *
+     * @return the spawn packet for this mannequin
+     */
+    public SpawnEntityPacket toSpawnPacket() {
+        return getSpawnPacket();
+    }
+
+    /**
+     * Gets the UUID of the player this mannequin impersonates.
+     *
+     * @return the original player UUID
+     */
+    public UUID getOriginalPlayerUuid() {
+        return originalPlayerUuid;
+    }
+
+    /**
+     * Gets the skin this mannequin is rendered with.
+     *
+     * @return the skin, or null for the default skin
+     */
+    public @Nullable PlayerSkin getSkin() {
+        return skin;
+    }
+}

--- a/game/src/main/java/net/onelitefeather/cygnus/entity/DeadPlayerMannequin.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/entity/DeadPlayerMannequin.java
@@ -54,7 +54,7 @@ public class DeadPlayerMannequin extends LivingEntity {
     }
 
     /**
-     * Creates a standing, packet-only jumpscare phantom for a player identity. Never call
+     * Creates a standing, packet-only JumpScare phantom for a player identity. Never call
      * {@link #setInstance} on the result, it only exists as raw packets sent to one victim.
      *
      * @param originalPlayerUuid the UUID of the player this phantom impersonates

--- a/game/src/main/java/net/onelitefeather/cygnus/entity/package-info.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/entity/package-info.java
@@ -1,0 +1,4 @@
+@NotNullByDefault
+package net.onelitefeather.cygnus.entity;
+
+import org.jetbrains.annotations.NotNullByDefault;

--- a/game/src/main/java/net/onelitefeather/cygnus/jumpscare/JumpScareManager.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/jumpscare/JumpScareManager.java
@@ -1,0 +1,256 @@
+package net.onelitefeather.cygnus.jumpscare;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.play.DestroyEntitiesPacket;
+import net.minestom.server.network.packet.server.play.EntityHeadLookPacket;
+import net.minestom.server.network.packet.server.play.ParticlePacket;
+
+import net.minestom.server.particle.Particle;
+import net.minestom.server.potion.Potion;
+import net.minestom.server.potion.PotionEffect;
+import net.minestom.server.timer.TaskSchedule;
+import net.onelitefeather.cygnus.entity.DeadPlayerMannequin;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Manages dead player mannequins and turnaround scare for surviving players.
+ *
+ * @author theEvilReaper
+ * @version 1.1.0
+ * @since 1.0.0
+ */
+public final class JumpScareManager {
+
+    private static final long COOLDOWN_MS = 60_000L; // 60 seconds
+    private static final float TRIGGER_CHANCE = 0.35f; // 35% chance on rapid turnaround
+    private static final float TURNAROUND_THRESHOLD_DEGREES = 120.0f;
+
+    private final List<DeadPlayerMannequin> activeMannequins;
+    private final Map<UUID, Long> jumpScareCooldowns;
+    private final Map<UUID, Float> playerLastYaws;
+    private final Random random;
+
+    public JumpScareManager() {
+        this.activeMannequins = new CopyOnWriteArrayList<>();
+        this.jumpScareCooldowns = new HashMap<>();
+        this.playerLastYaws = new HashMap<>();
+        this.random = new Random();
+    }
+
+    /**
+     * Adds an {@link DeadPlayerMannequin} instance to the manager
+     *
+     * @param mannequin to add
+     */
+    public void register(DeadPlayerMannequin mannequin) {
+        this.activeMannequins.add(mannequin);
+    }
+
+    /**
+     * Removes an {@link DeadPlayerMannequin} instance from the manager
+     *
+     * @param mannequin to remove
+     */
+    public void unregister(DeadPlayerMannequin mannequin) {
+        this.activeMannequins.remove(mannequin);
+    }
+
+    /**
+     * Checks if the provided {@link Player} makes a turn around.
+     *
+     * @param player to check
+     */
+    public void checkTurnAround(Player player) {
+        if (activeMannequins.isEmpty()) return;
+
+        float currentYaw = player.getPosition().yaw();
+        float previousYaw = playerLastYaws.getOrDefault(player.getUuid(), currentYaw);
+        playerLastYaws.put(player.getUuid(), currentYaw);
+
+        float yawDelta = Math.abs(currentYaw - previousYaw);
+        if (yawDelta > 180.0f) {
+            yawDelta = 360.0f - yawDelta;
+        }
+
+        if (yawDelta >= TURNAROUND_THRESHOLD_DEGREES) {
+            triggerIfEligible(player);
+        }
+    }
+
+    /**
+     * Checks if a scare could be executed on a {@link Player}.
+     *
+     * @param player who is involved
+     */
+    private void triggerIfEligible(Player player) {
+        long now = System.currentTimeMillis();
+        long lastScare = jumpScareCooldowns.getOrDefault(player.getUuid(), 0L);
+
+        if (now - lastScare < COOLDOWN_MS) {
+            return;
+        }
+
+        if (random.nextFloat() > TRIGGER_CHANCE) {
+            return;
+        }
+
+        execute(player);
+    }
+
+    /**
+     * Force a scare to a provided {@link Player}.
+     *
+     * @param player who retrieves it
+     * @return true when the execution was successfully otherwise false
+     */
+    public boolean force(Player player) {
+        return execute(player);
+    }
+
+    /**
+     * Executes the logic of the scare
+     *
+     * @param player who retrieves it
+     * @return true when the execution was successfully otherwise false
+     */
+    private boolean execute(Player player) {
+        if (activeMannequins.isEmpty()) return false;
+
+        DeadPlayerMannequin sampleCorpse = activeMannequins.get(random.nextInt(activeMannequins.size()));
+        if (sampleCorpse.getInstance() == null || sampleCorpse.isRemoved()) {
+            activeMannequins.remove(sampleCorpse);
+            return false;
+        }
+
+        jumpScareCooldowns.put(player.getUuid(), System.currentTimeMillis());
+
+        Pos playerPos = player.getPosition();
+        // Calculate strictly 2D horizontal forward vector on XZ plane at exact foot Y level
+        float yawRad = (float) Math.toRadians(playerPos.yaw());
+        double dirX = -Math.sin(yawRad);
+        double dirZ = Math.cos(yawRad);
+        double distance = 2.2; // 2.2 blocks in front
+
+        double phantomX = playerPos.x() + dirX * distance;
+        double phantomZ = playerPos.z() + dirZ * distance;
+        double eyeHeight = player.getEyeHeight();
+
+        Pos eyeToEyeView = new Pos(phantomX, playerPos.y() + eyeHeight, phantomZ)
+                .withLookAt(playerPos.add(0, eyeHeight, 0));
+
+        Pos jumpscarePos = new Pos(
+                phantomX,
+                playerPos.y(),
+                phantomZ,
+                eyeToEyeView.yaw(),
+                eyeToEyeView.pitch()
+        );
+
+        DeadPlayerMannequin phantom = DeadPlayerMannequin.standing(
+                sampleCorpse.getOriginalPlayerUuid(),
+                sampleCorpse.getSkin(),
+                jumpscarePos
+        );
+        int phantomEntityId = phantom.getEntityId();
+
+        sampleCorpse.updateViewableRule(viewer -> !viewer.equals(player));
+
+        player.sendPacket(phantom.toSpawnPacket());
+        player.sendPacket(phantom.getMetadataPacket());
+        player.sendPacket(new EntityHeadLookPacket(phantomEntityId, jumpscarePos.yaw()));
+
+        // Initial horror sound effect & Darkness
+        player.playSound(Sound.sound(
+                Key.key("entity.elder_guardian.curse"),
+                Sound.Source.HOSTILE,
+                1.0f,
+                0.6f
+        ));
+        player.addEffect(new Potion(PotionEffect.DARKNESS, (byte) 1, 40));
+
+        // Initial smoke pulse at spawn
+        player.sendPacket(new ParticlePacket(
+                Particle.SMOKE, true, false,
+                jumpscarePos.x(), jumpscarePos.y() + 1.0, jumpscarePos.z(),
+                0.3f, 0.5f, 0.3f, 0.05f, 25
+        ));
+
+        // Schedule smooth despawn transition after 2.5 seconds (50 ticks)
+        MinecraftServer.getSchedulerManager().buildTask(() -> {
+            if (player.isOnline()) {
+                // Smoke & Poof particle burst covering full body height
+                player.sendPacket(new ParticlePacket(
+                        Particle.POOF, true, false,
+                        jumpscarePos.x(), jumpscarePos.y() + 1.0, jumpscarePos.z(),
+                        0.4f, 0.8f, 0.4f, 0.05f, 35
+                ));
+                player.sendPacket(new ParticlePacket(
+                        Particle.LARGE_SMOKE, true, false,
+                        jumpscarePos.x(), jumpscarePos.y() + 1.0, jumpscarePos.z(),
+                        0.3f, 0.6f, 0.3f, 0.02f, 20
+                ));
+                // Ghostly dissolve sound
+                player.playSound(Sound.sound(
+                        Key.key("block.fire.extinguish"),
+                        Sound.Source.HOSTILE,
+                        0.7f,
+                        0.5f
+                ));
+                player.sendPacket(new DestroyEntitiesPacket(phantomEntityId));
+            }
+            restoreCorpseVisibility(sampleCorpse);
+        }).delay(TaskSchedule.tick(50)).schedule();
+
+        return true;
+    }
+
+    /**
+     * Updates corpse visibility of a given {@link DeadPlayerMannequin}.
+     *
+     * @param corpse to update
+     */
+    private void restoreCorpseVisibility(DeadPlayerMannequin corpse) {
+        if (corpse.getInstance() != null && !corpse.isRemoved()) {
+            corpse.updateViewableRule(null);
+        }
+    }
+
+    /**
+     * +
+     * Removes all existing mannequin from the {@link Instance}.
+     */
+    public void cleanUp() {
+        for (DeadPlayerMannequin mannequin : activeMannequins) {
+            if (mannequin.getInstance() != null && !mannequin.isRemoved()) {
+                mannequin.remove();
+            }
+        }
+        activeMannequins.clear();
+        jumpScareCooldowns.clear();
+        playerLastYaws.clear();
+    }
+
+    /**
+     * Returns an unmodifiable view of each active mannequin.
+     *
+     * @return the given list
+     */
+    @Contract(value = "-> new", pure = true)
+    public @NotNull List<DeadPlayerMannequin> getActiveMannequins() {
+        return Collections.unmodifiableList(activeMannequins);
+    }
+}

--- a/game/src/main/java/net/onelitefeather/cygnus/jumpscare/JumpScareManager.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/jumpscare/JumpScareManager.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * @author theEvilReaper
  * @version 1.1.0
- * @since 1.0.0
+ * @since 2.7.0
  */
 public final class JumpScareManager {
 

--- a/game/src/main/java/net/onelitefeather/cygnus/jumpscare/JumpScareManager.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/jumpscare/JumpScareManager.java
@@ -19,11 +19,12 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -42,6 +43,7 @@ public final class JumpScareManager {
     private final List<DeadPlayerMannequin> activeMannequins;
     private final Map<UUID, Long> jumpScareCooldowns;
     private final Map<UUID, Float> playerLastYaws;
+    private final Map<DeadPlayerMannequin, Set<UUID>> corpseHiddenFromViewers;
     private final Random random;
 
     /**
@@ -49,8 +51,9 @@ public final class JumpScareManager {
      */
     public JumpScareManager() {
         this.activeMannequins = new CopyOnWriteArrayList<>();
-        this.jumpScareCooldowns = new HashMap<>();
-        this.playerLastYaws = new HashMap<>();
+        this.jumpScareCooldowns = new ConcurrentHashMap<>();
+        this.playerLastYaws = new ConcurrentHashMap<>();
+        this.corpseHiddenFromViewers = new ConcurrentHashMap<>();
         this.random = new Random();
     }
 
@@ -133,11 +136,10 @@ public final class JumpScareManager {
     private boolean execute(Player player) {
         if (activeMannequins.isEmpty()) return false;
 
+        activeMannequins.removeIf(corpse -> corpse.getInstance() == null || corpse.isRemoved());
+        if (activeMannequins.isEmpty()) return false;
+
         DeadPlayerMannequin sampleCorpse = activeMannequins.get(random.nextInt(activeMannequins.size()));
-        if (sampleCorpse.getInstance() == null || sampleCorpse.isRemoved()) {
-            activeMannequins.remove(sampleCorpse);
-            return false;
-        }
 
         jumpScareCooldowns.put(player.getUuid(), System.currentTimeMillis());
 
@@ -150,7 +152,7 @@ public final class JumpScareManager {
         );
         int phantomEntityId = phantom.getEntityId();
 
-        sampleCorpse.updateViewableRule(viewer -> !viewer.equals(player));
+        hideCorpseFromViewer(sampleCorpse, player);
 
         player.sendPacket(phantom.toSpawnPacket());
         player.sendPacket(phantom.getMetadataPacket());
@@ -195,7 +197,7 @@ public final class JumpScareManager {
                 ));
                 player.sendPacket(new DestroyEntitiesPacket(phantomEntityId));
             }
-            restoreCorpseVisibility(sampleCorpse);
+            restoreCorpseVisibility(sampleCorpse, player);
         }).delay(TaskSchedule.tick(50)).schedule();
 
         return true;
@@ -233,18 +235,44 @@ public final class JumpScareManager {
     }
 
     /**
-     * Updates corpse visibility of a given {@link DeadPlayerMannequin}.
+     * Hides a corpse from a single victim without affecting any other viewer's visibility rule,
+     * even if another jumpscare is concurrently hiding the same corpse from a different victim.
      *
-     * @param corpse to update
+     * @param corpse the corpse to hide
+     * @param victim the player it should be hidden from
      */
-    private void restoreCorpseVisibility(DeadPlayerMannequin corpse) {
-        if (corpse.getInstance() != null && !corpse.isRemoved()) {
+    private void hideCorpseFromViewer(DeadPlayerMannequin corpse, Player victim) {
+        Set<UUID> hiddenFrom = corpseHiddenFromViewers.computeIfAbsent(corpse, _ -> ConcurrentHashMap.newKeySet());
+        hiddenFrom.add(victim.getUuid());
+        corpse.updateViewableRule(viewer -> !hiddenFrom.contains(viewer.getUuid()));
+    }
+
+    /**
+     * Restores corpse visibility for a single victim, leaving the corpse hidden for any other
+     * victim whose jumpscare against the same corpse is still active.
+     *
+     * @param corpse the corpse to update
+     * @param victim the player it should become visible to again
+     */
+    private void restoreCorpseVisibility(DeadPlayerMannequin corpse, Player victim) {
+        Set<UUID> hiddenFrom = corpseHiddenFromViewers.get(corpse);
+        if (hiddenFrom == null) return;
+        hiddenFrom.remove(victim.getUuid());
+
+        if (corpse.getInstance() == null || corpse.isRemoved()) {
+            corpseHiddenFromViewers.remove(corpse);
+            return;
+        }
+
+        if (hiddenFrom.isEmpty()) {
+            corpseHiddenFromViewers.remove(corpse);
             corpse.updateViewableRule(null);
+        } else {
+            corpse.updateViewableRule(viewer -> !hiddenFrom.contains(viewer.getUuid()));
         }
     }
 
     /**
-     * +
      * Removes all existing mannequin from the {@link Instance}.
      */
     public void cleanUp() {
@@ -256,6 +284,7 @@ public final class JumpScareManager {
         activeMannequins.clear();
         jumpScareCooldowns.clear();
         playerLastYaws.clear();
+        corpseHiddenFromViewers.clear();
     }
 
     /**

--- a/game/src/main/java/net/onelitefeather/cygnus/jumpscare/JumpScareManager.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/jumpscare/JumpScareManager.java
@@ -44,6 +44,9 @@ public final class JumpScareManager {
     private final Map<UUID, Float> playerLastYaws;
     private final Random random;
 
+    /**
+     * Creates a new instance of the service.
+     */
     public JumpScareManager() {
         this.activeMannequins = new CopyOnWriteArrayList<>();
         this.jumpScareCooldowns = new HashMap<>();
@@ -138,27 +141,7 @@ public final class JumpScareManager {
 
         jumpScareCooldowns.put(player.getUuid(), System.currentTimeMillis());
 
-        Pos playerPos = player.getPosition();
-        // Calculate strictly 2D horizontal forward vector on XZ plane at exact foot Y level
-        float yawRad = (float) Math.toRadians(playerPos.yaw());
-        double dirX = -Math.sin(yawRad);
-        double dirZ = Math.cos(yawRad);
-        double distance = 2.2; // 2.2 blocks in front
-
-        double phantomX = playerPos.x() + dirX * distance;
-        double phantomZ = playerPos.z() + dirZ * distance;
-        double eyeHeight = player.getEyeHeight();
-
-        Pos eyeToEyeView = new Pos(phantomX, playerPos.y() + eyeHeight, phantomZ)
-                .withLookAt(playerPos.add(0, eyeHeight, 0));
-
-        Pos jumpscarePos = new Pos(
-                phantomX,
-                playerPos.y(),
-                phantomZ,
-                eyeToEyeView.yaw(),
-                eyeToEyeView.pitch()
-        );
+        Pos jumpscarePos = getJumpscarePos(player);
 
         DeadPlayerMannequin phantom = DeadPlayerMannequin.standing(
                 sampleCorpse.getOriginalPlayerUuid(),
@@ -216,6 +199,37 @@ public final class JumpScareManager {
         }).delay(TaskSchedule.tick(50)).schedule();
 
         return true;
+    }
+
+    /**
+     * Extracts the position for the jump scare from a {@link Player} target.
+     *
+     * @param player which is the target
+     * @return extracted position
+     */
+    private static Pos getJumpscarePos(Player player) {
+        Pos playerPos = player.getPosition();
+        // Calculate strictly 2D horizontal forward vector on XZ plane at exact foot Y level
+        float yawRad = (float) Math.toRadians(playerPos.yaw());
+        double dirX = -Math.sin(yawRad);
+        double dirZ = Math.cos(yawRad);
+        double distance = 2.2; // 2.2 blocks in front
+
+        double phantomX = playerPos.x() + dirX * distance;
+        double phantomZ = playerPos.z() + dirZ * distance;
+        double eyeHeight = player.getEyeHeight();
+
+        Pos eyeToEyeView = new Pos(phantomX, playerPos.y() + eyeHeight, phantomZ)
+                .withLookAt(playerPos.add(0, eyeHeight, 0));
+
+        Pos jumpscarePos = new Pos(
+                phantomX,
+                playerPos.y(),
+                phantomZ,
+                eyeToEyeView.yaw(),
+                eyeToEyeView.pitch()
+        );
+        return jumpscarePos;
     }
 
     /**

--- a/game/src/main/java/net/onelitefeather/cygnus/jumpscare/package-info.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/jumpscare/package-info.java
@@ -1,0 +1,4 @@
+@NotNullByDefault
+package net.onelitefeather.cygnus.jumpscare;
+
+import org.jetbrains.annotations.NotNullByDefault;

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerDeathListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerDeathListener.java
@@ -12,7 +12,7 @@ import net.onelitefeather.cygnus.common.Messages;
 import net.onelitefeather.cygnus.common.Tags;
 import net.onelitefeather.cygnus.entity.DeadPlayerMannequin;
 import net.onelitefeather.cygnus.event.GameFinishEvent;
-import net.onelitefeather.cygnus.jumpscare.JumpscareManager;
+import net.onelitefeather.cygnus.jumpscare.JumpScareManager;
 import net.onelitefeather.cygnus.phase.GamePhase;
 import net.onelitefeather.cygnus.team.TeamHelper;
 
@@ -25,9 +25,9 @@ public final class PlayerDeathListener implements Consumer<PlayerDeathEvent> {
     private final Supplier<Phase> phaseSupplier;
     private final Team survivorTeam;
     private final Team slenderTeam;
-    private final JumpscareManager jumpscareManager;
+    private final JumpScareManager jumpscareManager;
 
-    public PlayerDeathListener(Supplier<Phase> phaseSupplier, TeamService teamService, JumpscareManager jumpscareManager) {
+    public PlayerDeathListener(Supplier<Phase> phaseSupplier, TeamService teamService, JumpScareManager jumpscareManager) {
         this.phaseSupplier = phaseSupplier;
         this.survivorTeam = teamService.getTeams().get(TeamHelper.SURVIVOR_TEAM_ID);
         this.slenderTeam = teamService.getTeams().get(TeamHelper.SLENDER_TEAM_ID);
@@ -42,7 +42,7 @@ public final class PlayerDeathListener implements Consumer<PlayerDeathEvent> {
             Pos deathPos = player.getPosition();
             DeadPlayerMannequin mannequin = DeadPlayerMannequin.sleeping(player);
             mannequin.setInstance(player.getInstance(), deathPos.add(0, 0.15, 0));
-            this.jumpscareManager.registerMannequin(mannequin);
+            this.jumpscareManager.register(mannequin);
         }
 
         event.setChatMessage(Messages.getDeathComponent(player));

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerDeathListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerDeathListener.java
@@ -5,11 +5,14 @@ import net.theevilreaper.xerus.api.team.Team;
 import net.theevilreaper.xerus.api.team.TeamService;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.player.PlayerDeathEvent;
 import net.onelitefeather.cygnus.common.Messages;
 import net.onelitefeather.cygnus.common.Tags;
+import net.onelitefeather.cygnus.entity.DeadPlayerMannequin;
 import net.onelitefeather.cygnus.event.GameFinishEvent;
+import net.onelitefeather.cygnus.jumpscare.JumpscareManager;
 import net.onelitefeather.cygnus.phase.GamePhase;
 import net.onelitefeather.cygnus.team.TeamHelper;
 
@@ -22,16 +25,26 @@ public final class PlayerDeathListener implements Consumer<PlayerDeathEvent> {
     private final Supplier<Phase> phaseSupplier;
     private final Team survivorTeam;
     private final Team slenderTeam;
+    private final JumpscareManager jumpscareManager;
 
-    public PlayerDeathListener(Supplier<Phase> phaseSupplier, TeamService teamService) {
+    public PlayerDeathListener(Supplier<Phase> phaseSupplier, TeamService teamService, JumpscareManager jumpscareManager) {
         this.phaseSupplier = phaseSupplier;
         this.survivorTeam = teamService.getTeams().get(TeamHelper.SURVIVOR_TEAM_ID);
         this.slenderTeam = teamService.getTeams().get(TeamHelper.SLENDER_TEAM_ID);
+        this.jumpscareManager = jumpscareManager;
     }
 
     @Override
     public void accept(PlayerDeathEvent event) {
         Player player = event.getPlayer();
+
+        if (survivorTeam.getPlayers().contains(player) && player.getInstance() != null) {
+            Pos deathPos = player.getPosition();
+            DeadPlayerMannequin mannequin = DeadPlayerMannequin.sleeping(player);
+            mannequin.setInstance(player.getInstance(), deathPos.add(0, 0.15, 0));
+            this.jumpscareManager.registerMannequin(mannequin);
+        }
+
         event.setChatMessage(Messages.getDeathComponent(player));
         survivorTeam.removePlayer(player);
         player.removeTag(Tags.TEAM_ID);
@@ -45,3 +58,4 @@ public final class PlayerDeathListener implements Consumer<PlayerDeathEvent> {
         gamePhase.finish();
     }
 }
+

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/player/CygnusPlayerTickListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/player/CygnusPlayerTickListener.java
@@ -2,15 +2,24 @@ package net.onelitefeather.cygnus.listener.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.player.PlayerTickEvent;
+import net.onelitefeather.cygnus.jumpscare.JumpScareManager;
 import net.onelitefeather.cygnus.player.CygnusPlayer;
 
 import java.util.function.Consumer;
 
 public final class CygnusPlayerTickListener implements Consumer<PlayerTickEvent> {
 
+    private final JumpScareManager jumpscareManager;
+
+    public CygnusPlayerTickListener(JumpScareManager jumpscareManager) {
+        this.jumpscareManager = jumpscareManager;
+    }
+
     @Override
     public void accept(PlayerTickEvent event) {
         Player player = event.getPlayer();
+
+        this.jumpscareManager.checkTurnAround(player);
 
         if (!(player instanceof CygnusPlayer cygnusPlayer)) return;
         if (!cygnusPlayer.hasBlockedSprinting()) return;
@@ -18,3 +27,4 @@ public final class CygnusPlayerTickListener implements Consumer<PlayerTickEvent>
         cygnusPlayer.sendPacket(cygnusPlayer.getMetadataPacket());
     }
 }
+

--- a/game/src/main/java/net/onelitefeather/cygnus/phase/GamePhase.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/phase/GamePhase.java
@@ -2,6 +2,7 @@ package net.onelitefeather.cygnus.phase;
 
 import net.minestom.server.event.EventDispatcher;
 import net.onelitefeather.cygnus.event.GameStartEvent;
+import net.onelitefeather.cygnus.jumpscare.JumpScareManager;
 import net.onelitefeather.cygnus.view.event.ViewUpdateEvent;
 import net.theevilreaper.xerus.api.phase.TickDirection;
 import net.theevilreaper.xerus.api.phase.TimedPhase;
@@ -23,24 +24,29 @@ import java.util.HashSet;
 public final class GamePhase extends TimedPhase {
 
     private final GameView gameView;
+    private final JumpScareManager jumpscareManager;
     private @Nullable GameFinishEvent finishEvent;
 
     /**
      * Creates a new instance from the {@link GamePhase}.
      *
-     * @param gameView        the view to update
-     * @param endRunnable     the runnable to execute on end
+     * @param gameView         the view to update
+     * @param endRunnable      the runnable to execute on end
+     * @param gameTime         the game time
+     * @param jumpscareManager the jumpscare manager instance
      */
     public GamePhase(
             GameView gameView,
             Runnable endRunnable,
-            int gameTime
+            int gameTime,
+            JumpScareManager jumpscareManager
     ) {
         super("GamePhase", ChronoUnit.SECONDS, 1);
         this.setCurrentTicks(gameTime);
         this.setTickDirection(TickDirection.DOWN);
         this.setEndTicks(0);
         this.gameView = gameView;
+        this.jumpscareManager = jumpscareManager;
         this.setFinishedCallback(endRunnable);
     }
 
@@ -57,7 +63,7 @@ public final class GamePhase extends TimedPhase {
     @Override
     public void onStart() {
         super.onStart();
-        addListener(PlayerTickEvent.class, new CygnusPlayerTickListener());
+        addListener(PlayerTickEvent.class, new CygnusPlayerTickListener(this.jumpscareManager));
         EventDispatcher.call(new GameStartEvent());
     }
 
@@ -76,3 +82,4 @@ public final class GamePhase extends TimedPhase {
         EventDispatcher.call(new ViewUpdateEvent(getCurrentTicks()));
     }
 }
+

--- a/game/src/test/java/net/onelitefeather/cygnus/jumpscare/JumpScareManagerTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/jumpscare/JumpScareManagerTest.java
@@ -171,4 +171,53 @@ class JumpScareManagerTest extends CygnusPlayerTestBase {
 
         env.destroyInstance(instance, true);
     }
+
+    @Test
+    void testConcurrentJumpScaresAgainstSameCorpseDoNotLeakVisibility(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Pos deathPos = new Pos(10, 41, 10);
+
+        TestConnection corpseOwnerConn = env.createConnection();
+        Player corpseOwner = corpseOwnerConn.connect(instance, deathPos);
+
+        TestConnection victimAConn = env.createConnection();
+        Player victimA = victimAConn.connect(instance, new Pos(12, 41, 10));
+
+        TestConnection victimBConn = env.createConnection();
+        Player victimB = victimBConn.connect(instance, new Pos(8, 41, 10));
+
+        DeadPlayerMannequin corpse = DeadPlayerMannequin.sleeping(corpseOwner);
+        corpse.setInstance(instance, deathPos);
+
+        JumpScareManager manager = new JumpScareManager();
+        manager.register(corpse);
+
+        for (int i = 0; i < 5; i++) env.tick();
+
+        // Victim A's scare starts first.
+        assertTrue(manager.force(victimA));
+        assertFalse(corpse.isViewer(victimA), "corpse must be hidden from victim A during their scare");
+
+        // A few ticks later, victim B triggers a scare against the same corpse while A's is still active.
+        for (int i = 0; i < 5; i++) env.tick();
+        assertTrue(manager.force(victimB));
+
+        assertFalse(corpse.isViewer(victimA),
+                "victim B's scare must not re-reveal the corpse to victim A, whose own scare is still running");
+        assertFalse(corpse.isViewer(victimB), "corpse must be hidden from victim B during their scare");
+
+        // Advance to just past A's despawn (50 ticks after A's trigger), but before B's (50 ticks after B's trigger).
+        for (int i = 0; i < 46; i++) env.tick();
+
+        assertTrue(corpse.isViewer(victimA), "victim A should see the corpse again once their own scare despawns");
+        assertFalse(corpse.isViewer(victimB),
+                "victim A's despawn must not restore visibility for victim B, whose scare is still active");
+
+        // Advance past B's despawn too.
+        for (int i = 0; i < 10; i++) env.tick();
+
+        assertTrue(corpse.isViewer(victimB), "victim B should see the corpse again once their own scare despawns");
+
+        env.destroyInstance(instance, true);
+    }
 }

--- a/game/src/test/java/net/onelitefeather/cygnus/jumpscare/JumpScareManagerTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/jumpscare/JumpScareManagerTest.java
@@ -1,0 +1,174 @@
+package net.onelitefeather.cygnus.jumpscare;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.play.DestroyEntitiesPacket;
+import net.minestom.server.network.packet.server.play.SpawnEntityPacket;
+import net.minestom.testing.Collector;
+import net.minestom.testing.Env;
+import net.minestom.testing.TestConnection;
+import net.onelitefeather.cygnus.CygnusPlayerTestBase;
+import net.onelitefeather.cygnus.entity.DeadPlayerMannequin;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit/Integration test for {@link JumpScareManager} and {@link DeadPlayerMannequin}.
+ *
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+class JumpScareManagerTest extends CygnusPlayerTestBase {
+
+    @Test
+    void testRegisterAndUnregisterMannequin(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        DeadPlayerMannequin mannequin = DeadPlayerMannequin.sleeping(player);
+        JumpScareManager manager = new JumpScareManager();
+
+        assertTrue(manager.getActiveMannequins().isEmpty());
+
+        manager.register(mannequin);
+        assertEquals(1, manager.getActiveMannequins().size());
+
+        manager.unregister(mannequin);
+        assertTrue(manager.getActiveMannequins().isEmpty());
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testCleanUp(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+        Pos deathPos = new Pos(10, 64, 10);
+
+        DeadPlayerMannequin mannequin = DeadPlayerMannequin.sleeping(player);
+        mannequin.setInstance(instance, deathPos);
+
+        JumpScareManager manager = new JumpScareManager();
+        manager.register(mannequin);
+
+        assertEquals(1, manager.getActiveMannequins().size());
+
+        manager.cleanUp();
+
+        assertTrue(manager.getActiveMannequins().isEmpty());
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testJumpScarePhantomOnlySentToVictim(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Pos deathPos = new Pos(10, 41, 10);
+
+        TestConnection corpseOwnerConn = env.createConnection();
+        Player corpseOwner = corpseOwnerConn.connect(instance, deathPos);
+
+        TestConnection victimConn = env.createConnection();
+        Player victim = victimConn.connect(instance, new Pos(12, 41, 10));
+
+        TestConnection bystanderConn = env.createConnection();
+        Player bystander = bystanderConn.connect(instance, new Pos(11, 41, 10));
+
+        DeadPlayerMannequin corpse = DeadPlayerMannequin.sleeping(corpseOwner);
+        corpse.setInstance(instance, deathPos);
+
+        JumpScareManager manager = new JumpScareManager();
+        manager.register(corpse);
+
+        // Let auto-viewability establish before triggering, so the "before" state is known.
+        for (int i = 0; i < 5; i++) env.tick();
+        assertTrue(corpse.isViewer(victim), "corpse should be visible to the victim before the scare");
+        assertTrue(corpse.isViewer(bystander), "corpse should be visible to the bystander before the scare");
+
+        Collector<SpawnEntityPacket> victimSpawns = victimConn.trackIncoming(SpawnEntityPacket.class);
+        Collector<SpawnEntityPacket> bystanderSpawns = bystanderConn.trackIncoming(SpawnEntityPacket.class);
+
+        assertTrue(manager.force(victim));
+
+        List<SpawnEntityPacket> victimPackets = victimSpawns.collect();
+        List<SpawnEntityPacket> bystanderPackets = bystanderSpawns.collect();
+
+        assertEquals(1, victimPackets.size(), "the victim must receive exactly the phantom's spawn packet");
+        assertEquals(EntityType.MANNEQUIN, victimPackets.getFirst().type());
+        assertTrue(bystanderPackets.isEmpty(), "a bystander must never receive the phantom's spawn packet");
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testJumpScareHidesOriginalCorpseOnlyFromVictim(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Pos deathPos = new Pos(10, 41, 10);
+
+        TestConnection corpseOwnerConn = env.createConnection();
+        Player corpseOwner = corpseOwnerConn.connect(instance, deathPos);
+
+        TestConnection victimConn = env.createConnection();
+        Player victim = victimConn.connect(instance, new Pos(12, 41, 10));
+
+        TestConnection bystanderConn = env.createConnection();
+        Player bystander = bystanderConn.connect(instance, new Pos(11, 41, 10));
+
+        DeadPlayerMannequin corpse = DeadPlayerMannequin.sleeping(corpseOwner);
+        corpse.setInstance(instance, deathPos);
+
+        JumpScareManager manager = new JumpScareManager();
+        manager.register(corpse);
+
+        for (int i = 0; i < 5; i++) env.tick();
+        assertTrue(corpse.isViewer(victim));
+        assertTrue(corpse.isViewer(bystander));
+
+        assertTrue(manager.force(victim));
+
+        assertFalse(corpse.isViewer(victim), "the victim must not see the resting corpse while the phantom stands behind them");
+        assertTrue(corpse.isViewer(bystander), "a bystander must keep seeing the resting corpse untouched");
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testCorpseVisibilityRestoredAfterJumpScareDespawn(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Pos deathPos = new Pos(10, 41, 10);
+
+        TestConnection corpseOwnerConn = env.createConnection();
+        Player corpseOwner = corpseOwnerConn.connect(instance, deathPos);
+
+        TestConnection victimConn = env.createConnection();
+        Player victim = victimConn.connect(instance, new Pos(12, 41, 10));
+
+        DeadPlayerMannequin corpse = DeadPlayerMannequin.sleeping(corpseOwner);
+        corpse.setInstance(instance, deathPos);
+
+        JumpScareManager manager = new JumpScareManager();
+        manager.register(corpse);
+
+        for (int i = 0; i < 5; i++) env.tick();
+        assertTrue(manager.force(victim));
+        assertFalse(corpse.isViewer(victim));
+
+        Collector<DestroyEntitiesPacket> destroyPackets = victimConn.trackIncoming(DestroyEntitiesPacket.class);
+
+        // Despawn is scheduled 50 ticks after the trigger.
+        for (int i = 0; i < 55; i++) env.tick();
+
+        assertTrue(corpse.isViewer(victim), "the victim should see the real corpse again once the phantom despawns");
+        assertFalse(destroyPackets.collect().isEmpty(), "the victim should receive a destroy packet for the despawned phantom");
+
+        env.destroyInstance(instance, true);
+    }
+}


### PR DESCRIPTION
## Proposed changes

When a player dies, their entity is normally removed from the game. To make the world feel more immersive, this pull request leaves behind a dead mannequin at the player's death location, indicating where someone died.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...