### PR TITLE
fix(map): accept the 26.2 world layout when filtering maps

### DIFF
--- a/common/src/main/java/net/onelitefeather/cygnus/common/map/filter/MapFilters.java
+++ b/common/src/main/java/net/onelitefeather/cygnus/common/map/filter/MapFilters.java
@@ -1,7 +1,5 @@
 package net.onelitefeather.cygnus.common.map.filter;
 
-import net.kyori.adventure.key.Key;
-import net.minestom.server.world.DimensionType;
 import net.theevilreaper.aves.map.MapEntry;
 import org.jetbrains.annotations.Unmodifiable;
 
@@ -23,7 +21,6 @@ public final class MapFilters {
     private static final String REGION_FOLDER = "region";
     private static final String DIMENSIONS_FOLDER = "dimensions";
     private static final String MAP_FILE_NAME = "map.json";
-    private static final Key OVERWORLD_KEY = DimensionType.OVERWORLD.key();
 
     private MapFilters() {
 
@@ -59,22 +56,18 @@ public final class MapFilters {
     }
 
     /**
-     * Checks whether the given world root holds the region files of the overworld.
+     * Checks whether the given world root holds chunk data.
      *
-     * <p>A world written by 26.2 keeps its region files below
-     * {@code dimensions/<namespace>/<dimension>/region}, while a world written before that keeps
-     * them in a {@code region} directory next to {@code level.dat}. Both chunk loaders the project
-     * uses read the current layout and fall back to the legacy one, so a world counts as a map as
-     * soon as one of the two directories exists.</p>
+     * <p>A world written by 26.2 keeps its region files below {@code dimensions}, one directory per
+     * dimension, while a world written before that keeps them in a {@code region} directory next to
+     * {@code level.dat}. Which dimension is read is up to the chunk loader, so the filter only asks
+     * whether one of the two directories is there.</p>
      *
      * @param worldRoot the root directory of the world
      * @return {@code true} if the world holds region files in either layout, otherwise {@code false}
      */
     private static boolean hasRegionFolder(Path worldRoot) {
-        Path dimensionRegion = worldRoot.resolve(DIMENSIONS_FOLDER)
-                .resolve(OVERWORLD_KEY.namespace())
-                .resolve(OVERWORLD_KEY.value())
-                .resolve(REGION_FOLDER);
-        return Files.isDirectory(dimensionRegion) || Files.isDirectory(worldRoot.resolve(REGION_FOLDER));
+        return Files.isDirectory(worldRoot.resolve(DIMENSIONS_FOLDER))
+                || Files.isDirectory(worldRoot.resolve(REGION_FOLDER));
     }
 }

--- a/common/src/main/java/net/onelitefeather/cygnus/common/map/filter/MapFilters.java
+++ b/common/src/main/java/net/onelitefeather/cygnus/common/map/filter/MapFilters.java
@@ -1,5 +1,7 @@
 package net.onelitefeather.cygnus.common.map.filter;
 
+import net.kyori.adventure.key.Key;
+import net.minestom.server.world.DimensionType;
 import net.theevilreaper.aves.map.MapEntry;
 import org.jetbrains.annotations.Unmodifiable;
 
@@ -13,13 +15,15 @@ import java.util.stream.Stream;
  * The game module needs another filter to logic than the setup.
  *
  * @author theEvilReaper
- * @version 1.1.0
+ * @version 1.2.0
  * @since 1.0.0
  */
 public final class MapFilters {
 
     private static final String REGION_FOLDER = "region";
+    private static final String DIMENSIONS_FOLDER = "dimensions";
     private static final String MAP_FILE_NAME = "map.json";
+    private static final Key OVERWORLD_KEY = DimensionType.OVERWORLD.key();
 
     private MapFilters() {
 
@@ -34,7 +38,7 @@ public final class MapFilters {
     public static @Unmodifiable List<MapEntry> filterMapsForGame(Stream<Path> mapStream) {
         return mapStream
                 .filter(Files::isDirectory)
-                .filter(path -> Files.exists(path.resolve(REGION_FOLDER)))
+                .filter(MapFilters::hasRegionFolder)
                 .filter(path -> Files.exists(path.resolve(MAP_FILE_NAME)))
                 .map(MapEntry::of)
                 .toList();
@@ -49,8 +53,28 @@ public final class MapFilters {
     public static @Unmodifiable List<MapEntry> filterMapsForSetup(Stream<Path> mapStream) {
         return mapStream
                 .filter(Files::isDirectory)
-                .filter(path -> Files.exists(path.resolve(REGION_FOLDER)))
+                .filter(MapFilters::hasRegionFolder)
                 .map(MapEntry::of)
                 .toList();
+    }
+
+    /**
+     * Checks whether the given world root holds the region files of the overworld.
+     *
+     * <p>A world written by 26.2 keeps its region files below
+     * {@code dimensions/<namespace>/<dimension>/region}, while a world written before that keeps
+     * them in a {@code region} directory next to {@code level.dat}. Both chunk loaders the project
+     * uses read the current layout and fall back to the legacy one, so a world counts as a map as
+     * soon as one of the two directories exists.</p>
+     *
+     * @param worldRoot the root directory of the world
+     * @return {@code true} if the world holds region files in either layout, otherwise {@code false}
+     */
+    private static boolean hasRegionFolder(Path worldRoot) {
+        Path dimensionRegion = worldRoot.resolve(DIMENSIONS_FOLDER)
+                .resolve(OVERWORLD_KEY.namespace())
+                .resolve(OVERWORLD_KEY.value())
+                .resolve(REGION_FOLDER);
+        return Files.isDirectory(dimensionRegion) || Files.isDirectory(worldRoot.resolve(REGION_FOLDER));
     }
 }

--- a/common/src/test/java/net/onelitefeather/cygnus/common/map/filter/MapFiltersTest.java
+++ b/common/src/test/java/net/onelitefeather/cygnus/common/map/filter/MapFiltersTest.java
@@ -16,8 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies that both world layouts are recognized as maps: the one 26.2 writes, where the region
- * files live below {@code dimensions/minecraft/overworld}, and the legacy one which keeps them in a
- * {@code region} directory next to {@code level.dat}.
+ * files live below {@code dimensions}, and the legacy one which keeps them in a {@code region}
+ * directory next to {@code level.dat}.
  *
  * @author TheMeinerLP
  * @version 1.0.0
@@ -46,6 +46,14 @@ class MapFiltersTest {
 
         assertEquals(1, entries.size());
         assertEquals(arena, entries.getFirst().getDirectoryRoot());
+    }
+
+    @Test
+    void testGameFilterAcceptsBareDimensionsFolder(@TempDir Path maps) throws IOException {
+        Path arena = Files.createDirectories(maps.resolve("arena").resolve("dimensions")).getParent();
+        Files.writeString(arena.resolve("map.json"), "{}", StandardCharsets.UTF_8);
+
+        assertEquals(1, filterForGame(maps).size());
     }
 
     @Test

--- a/common/src/test/java/net/onelitefeather/cygnus/common/map/filter/MapFiltersTest.java
+++ b/common/src/test/java/net/onelitefeather/cygnus/common/map/filter/MapFiltersTest.java
@@ -1,0 +1,130 @@
+package net.onelitefeather.cygnus.common.map.filter;
+
+import net.theevilreaper.aves.map.MapEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that both world layouts are recognized as maps: the one 26.2 writes, where the region
+ * files live below {@code dimensions/minecraft/overworld}, and the legacy one which keeps them in a
+ * {@code region} directory next to {@code level.dat}.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 2.6.7
+ */
+class MapFiltersTest {
+
+    @Test
+    void testGameFilterAcceptsDimensionLayout(@TempDir Path maps) throws IOException {
+        Path arena = writeDimensionLayoutMap(maps.resolve("arena"));
+        Files.writeString(arena.resolve("map.json"), "{}", StandardCharsets.UTF_8);
+
+        List<MapEntry> entries = filterForGame(maps);
+
+        assertEquals(1, entries.size());
+        assertEquals(arena, entries.getFirst().getDirectoryRoot());
+        assertTrue(entries.getFirst().hasMapFile());
+    }
+
+    @Test
+    void testGameFilterAcceptsLegacyLayout(@TempDir Path maps) throws IOException {
+        Path arena = writeLegacyLayoutMap(maps.resolve("arena"));
+        Files.writeString(arena.resolve("map.json"), "{}", StandardCharsets.UTF_8);
+
+        List<MapEntry> entries = filterForGame(maps);
+
+        assertEquals(1, entries.size());
+        assertEquals(arena, entries.getFirst().getDirectoryRoot());
+    }
+
+    @Test
+    void testGameFilterSkipsMapWithoutMapFile(@TempDir Path maps) throws IOException {
+        writeDimensionLayoutMap(maps.resolve("arena"));
+
+        assertTrue(filterForGame(maps).isEmpty());
+    }
+
+    @Test
+    void testGameFilterSkipsDirectoryWithoutRegions(@TempDir Path maps) throws IOException {
+        Path arena = Files.createDirectories(maps.resolve("arena"));
+        Files.writeString(arena.resolve("map.json"), "{}", StandardCharsets.UTF_8);
+
+        assertTrue(filterForGame(maps).isEmpty());
+    }
+
+    @Test
+    void testSetupFilterAcceptsBothLayouts(@TempDir Path maps) throws IOException {
+        writeDimensionLayoutMap(maps.resolve("arena"));
+        writeLegacyLayoutMap(maps.resolve("lobby"));
+
+        assertEquals(2, filterForSetup(maps).size());
+    }
+
+    @Test
+    void testSetupFilterSkipsDirectoryWithoutRegions(@TempDir Path maps) throws IOException {
+        Files.createDirectories(maps.resolve("arena"));
+
+        assertTrue(filterForSetup(maps).isEmpty());
+    }
+
+    /**
+     * Runs the game filter over the direct children of the given directory.
+     *
+     * @param maps the directory which holds the world directories
+     * @return the entries the filter accepted
+     * @throws IOException if the directory cannot be listed
+     */
+    private List<MapEntry> filterForGame(Path maps) throws IOException {
+        try (Stream<Path> stream = Files.list(maps)) {
+            return MapFilters.filterMapsForGame(stream);
+        }
+    }
+
+    /**
+     * Runs the setup filter over the direct children of the given directory.
+     *
+     * @param maps the directory which holds the world directories
+     * @return the entries the filter accepted
+     * @throws IOException if the directory cannot be listed
+     */
+    private List<MapEntry> filterForSetup(Path maps) throws IOException {
+        try (Stream<Path> stream = Files.list(maps)) {
+            return MapFilters.filterMapsForSetup(stream);
+        }
+    }
+
+    /**
+     * Writes a world directory in the layout 26.2 uses.
+     *
+     * @param worldRoot the root directory of the world
+     * @return the written world root
+     * @throws IOException if the layout cannot be written
+     */
+    private Path writeDimensionLayoutMap(Path worldRoot) throws IOException {
+        Files.createDirectories(worldRoot.resolve("dimensions").resolve("minecraft").resolve("overworld").resolve("region"));
+        return worldRoot;
+    }
+
+    /**
+     * Writes a world directory in the layout used before 26.2.
+     *
+     * @param worldRoot the root directory of the world
+     * @return the written world root
+     * @throws IOException if the layout cannot be written
+     */
+    private Path writeLegacyLayoutMap(Path worldRoot) throws IOException {
+        Files.createDirectories(worldRoot.resolve("region"));
+        return worldRoot;
+    }
+}

--- a/game/src/test/java/net/onelitefeather/cygnus/map/GameMapProviderIntegrationTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/map/GameMapProviderIntegrationTest.java
@@ -87,25 +87,33 @@ class GameMapProviderIntegrationTest {
      */
     private GameMapProvider createProvider(Path root) throws IOException {
         Path maps = root.resolve("game").resolve("maps");
-        writeMap(maps.resolve("lobby"), new BaseMap("lobby", Pos.ZERO, List.of()));
+        writeMap(maps.resolve("lobby"), new BaseMap("lobby", Pos.ZERO, List.of()), false);
         writeMap(
                 maps.resolve(ARENA_NAME),
-                new GameMap(ARENA_NAME, Pos.ZERO, new Pos(1, 1, 1), Set.of(), Set.of(new Pos(2, 2, 2)), List.of())
+                new GameMap(ARENA_NAME, Pos.ZERO, new Pos(1, 1, 1), Set.of(), Set.of(new Pos(2, 2, 2)), List.of()),
+                true
         );
         return new GameMapProvider(root);
     }
 
     /**
-     * Writes a map directory the way {@code MapFilters} expects it: a {@code region} directory next
-     * to a {@code map.json}. The directory stays empty, so the loader simply finds no region file
-     * and hands out no chunk — which is all this test needs from it.
+     * Writes a map directory the way {@code MapFilters} expects it: a region directory next to a
+     * {@code map.json}. The directory stays empty, so the loader simply finds no region file and
+     * hands out no chunk — which is all this test needs from it.
      *
-     * @param directoryRoot the world root of the map
-     * @param map           the map data written to {@code map.json}
+     * <p>The lobby is written in the layout used before 26.2 and the game map in the one 26.2
+     * writes, so a single provider covers both.</p>
+     *
+     * @param directoryRoot   the world root of the map
+     * @param map             the map data written to {@code map.json}
+     * @param dimensionLayout whether the region directory is written below {@code dimensions}
      * @throws IOException if the layout cannot be written
      */
-    private void writeMap(Path directoryRoot, BaseMap map) throws IOException {
-        Files.createDirectories(directoryRoot.resolve("region"));
+    private void writeMap(Path directoryRoot, BaseMap map, boolean dimensionLayout) throws IOException {
+        Path regionDirectory = dimensionLayout
+                ? directoryRoot.resolve("dimensions").resolve("minecraft").resolve("overworld").resolve("region")
+                : directoryRoot.resolve("region");
+        Files.createDirectories(regionDirectory);
         Files.writeString(directoryRoot.resolve("map.json"), GsonHelper.GSON.toJson(map), StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## Problem

Maps generated with 26.2 are never loaded. `MapFilters` accepts a world directory only when a `region` directory sits next to `level.dat`, but since 26.2 a world stores its region files below `dimensions/<namespace>/<dimension>/region`. Such a world is dropped by the filter, so `GameMapProvider` ends in `No maps found in the given path` / `No game map found` and the setup module lists no maps at all.

Both chunk loaders in use already read the current layout: `FalcoAnvilLoader` resolves `dimensions/<ns>/<dim>/region` and falls back to `region`, Minestom's `AnvilLoader(path, dimension)` resolves the dimension path directly. Only the filter in front of them was still tied to the old layout.

## Change

- `MapFilters` now accepts a world directory when either a `dimensions` directory or the legacy `region` directory is present. Which dimension is read is up to the chunk loader, so the filter does not resolve a dimension path itself. Applies to the game filter and the setup filter alike, so worlds written before 26.2 keep working.

## Tests

- New `MapFiltersTest` covers both layouts, the missing `map.json` case and a directory without any region data, for both filters.
- `GameMapProviderIntegrationTest` now writes its lobby in the legacy layout and its game map in the 26.2 layout, so one provider run exercises both.

`./gradlew test` is green.