### PR TITLE
chore(deps): switch to net.onelitefeather:minestom-extensions 2.1.1

### DIFF
--- a/bridge/build.gradle.kts
+++ b/bridge/build.gradle.kts
@@ -14,7 +14,8 @@ dependencies {
     compileOnly(platform(libs.aonyx.bom))
     compileOnly(libs.minestom)
     compileOnly(libs.adventure)
-    compileOnly(libs.minestom.ce.extensions)
+    compileOnly(platform(libs.minestom.extensions.bom))
+    compileOnly(libs.minestom.extensions)
 
     compileOnly(platform(libs.cloudnet.bom))
     compileOnly(libs.cloudnet.driver.api)

--- a/bridge/build.gradle.kts
+++ b/bridge/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 plugins {
     id("cygnus.java-conventions")
     `maven-publish`
@@ -16,6 +14,9 @@ dependencies {
     compileOnly(libs.adventure)
     compileOnly(platform(libs.minestom.extensions.bom))
     compileOnly(libs.minestom.extensions)
+    compileOnly(libs.minestom.extensions.processor)
+    annotationProcessor(platform(libs.minestom.extensions.bom))
+    annotationProcessor(libs.minestom.extensions.processor)
 
     compileOnly(platform(libs.cloudnet.bom))
     compileOnly(libs.cloudnet.driver.api)
@@ -23,14 +24,11 @@ dependencies {
     compileOnly(libs.cloudnet.bridge.impl)
 }
 
-// Stamp the version into extension.json (@version@ placeholder). Subprojects do not inherit the
-// root version, so read it from the root project - the same source the publications use.
-tasks.processResources {
-    val tokens = mapOf("version" to rootProject.version.toString())
-    inputs.properties(tokens)
-    filesMatching("extension.json") {
-        filter<ReplaceTokens>("tokens" to tokens)
-    }
+// The annotation processor generates extension.json but cannot know the project version. Subprojects
+// do not inherit the root version, so read it from the root project - the same source the
+// publications use.
+tasks.compileJava {
+    options.compilerArgs.add("-Aminestom.extension.version=${rootProject.version}")
 }
 
 publishing {

--- a/bridge/src/main/java/net/onelitefeather/cygnus/bridge/CygnusBridgePermissionExtension.java
+++ b/bridge/src/main/java/net/onelitefeather/cygnus/bridge/CygnusBridgePermissionExtension.java
@@ -5,6 +5,7 @@ import eu.cloudnetservice.modules.bridge.impl.platform.minestom.MinestomPermissi
 import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.util.TriState;
 import net.minestom.server.extensions.Extension;
+import net.onelitefeather.minestom.extensions.processor.ExtensionInfo;
 
 /**
  * Minestom extension that teaches the CloudNet bridge how Cygnus resolves permissions.
@@ -16,15 +17,23 @@ import net.minestom.server.extensions.Extension;
  * the same pointer LuckPerms and our {@code /stop} command read, and marks it the registry default.
  * <p>
  * {@link MinestomPermissionChecker} only exists inside the CloudNet bridge's extension classloader,
- * so this glue cannot live in the application. Declaring a dependency on the {@code CloudNet_Bridge}
- * extension (see {@code extension.json}) makes this extension load after the bridge and share its
- * classloader hierarchy. Minestom and Adventure come from the application classloader above, so the
- * pointer read here is the very one the player carries.
+ * so this glue cannot live in the application. The {@code CloudNet_Bridge} dependency declared below
+ * makes this extension load after the bridge and share its classloader hierarchy. Minestom and
+ * Adventure come from the application classloader above, so the pointer read here is the very one
+ * the player carries.
+ * <p>
+ * {@link ExtensionInfo} generates {@code extension.json} at compile time; the version is supplied by
+ * the build through {@code -Aminestom.extension.version}.
  *
  * @author TheMeinerLP
  * @version 1.0.0
  * @since 2.6.7
  **/
+@ExtensionInfo(
+        name = "CygnusCloudNetPermissions",
+        authors = "OneLiteFeather",
+        dependencies = "CloudNet_Bridge"
+)
 public final class CygnusBridgePermissionExtension extends Extension {
 
     @Override

--- a/bridge/src/main/resources/extension.json
+++ b/bridge/src/main/resources/extension.json
@@ -1,7 +1,0 @@
-{
-  "name": "CygnusCloudNetPermissions",
-  "version": "@version@",
-  "entrypoint": "net.onelitefeather.cygnus.bridge.CygnusBridgePermissionExtension",
-  "authors": ["OneLiteFeather"],
-  "dependencies": ["CloudNet_Bridge"]
-}

--- a/game/build.gradle.kts
+++ b/game/build.gradle.kts
@@ -27,8 +27,8 @@ dependencies {
     // CloudNet is provided by the CloudNet wrapper at runtime and its bridge is loaded as a
     // Minestom extension (separate classloader, see the :bridge module), so :game neither
     // references nor bundles any CloudNet artifact.
-    implementation(libs.minestom.ce.extensions)
-    implementation(libs.kotlin.stdlib.jdk8)
+    implementation(platform(libs.minestom.extensions.bom))
+    implementation(libs.minestom.extensions)
 
     // LuckPerms; guava used to arrive transitively through CloudNet, so bundle it explicitly now.
     implementation(libs.guava)

--- a/game/src/main/java/net/onelitefeather/cygnus/CygnusLoader.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/CygnusLoader.java
@@ -8,7 +8,7 @@ import net.onelitefeather.cygnus.common.dimension.DimensionFactory;
 public final class CygnusLoader {
 
     static void main() {
-        // minestom-ce-extensions loads platform extensions - the CloudNet bridge and our
+        // minestom-extensions loads platform extensions - the CloudNet bridge and our
         // :bridge permission extension among them - from the extensions/ folder. Running
         // standalone simply loads none. This also performs MinecraftServer.init().
         ExtensionBootstrap bootstrap = ExtensionBootstrap.init();

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -62,6 +62,9 @@ dependencyResolutionManagement {
             // DependencyGetter, so no Kotlin stdlib is needed on the class path anymore.
             library("minestom-extensions-bom", "net.onelitefeather", "minestom-extensions-bom").versionRef("minestom-extensions")
             library("minestom-extensions", "net.onelitefeather", "minestom-extensions").withoutVersion()
+            // Generates extension.json from @ExtensionInfo at compile time; source retention, so
+            // the annotation itself never reaches the extension jar.
+            library("minestom-extensions-processor", "net.onelitefeather", "minestom-extensions-processor").withoutVersion()
             library("adventure", "net.kyori", "adventure-text-minimessage").withoutVersion()
             library("cyano", "net.onelitefeather", "cyano").withoutVersion()
             library("guira", "net.onelitefeather", "guira").withoutVersion()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,11 +3,17 @@ rootProject.name = "Cygnus"
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // minestom-ce-extensions pulls com.github.Minestom:DependencyGetter from JitPack;
-        // resolve it through the OneLiteFeather reposilite proxy that caches JitPack.
+        // Reposilite proxy in front of JitPack, for catalog entries that resolve from
+        // com.github.* (Canis).
         maven {
             name = "reposiliteRepositoryOnelitefeatherProxy"
             url = uri("https://repo.onelitefeather.dev/onelitefeather-proxy")
+        }
+        // minestom-extensions is published here and, unlike the onelitefeather repository
+        // below, needs no credentials - keep it separate so a fresh clone resolves it.
+        maven {
+            name = "OneLiteFeatherReleases"
+            url = uri("https://repo.onelitefeather.dev/releases")
         }
         maven("https://central.sonatype.com/repository/maven-snapshots/")
         maven("https://repository.derklaro.dev/snapshots/")
@@ -40,8 +46,7 @@ dependencyResolutionManagement {
             version("luckperms-minestom-loader", "5.6-SNAPSHOT")
             version("guava", "33.6.0-jre")
             version("falco", "1.0.0")
-            version("minestom-ce-extensions", "1.2.0")
-            version("kotlin", "2.4.0")
+            version("minestom-extensions", "2.1.1")
 
             library("aonyx.bom", "net.onelitefeather", "aonyx-bom").versionRef("aonyx")
             library("slf4j.api", "org.slf4j", "slf4j-api").versionRef("slf4j")
@@ -51,11 +56,12 @@ dependencyResolutionManagement {
             library("luckperms.minestom.loader", "net.luckperms", "minestom-loader").versionRef("luckperms-minestom-loader")
 
             library("minestom", "net.minestom", "minestom").withoutVersion()
-            library("minestom-ce-extensions", "dev.hollowcube", "minestom-ce-extensions").versionRef("minestom-ce-extensions")
-            // minestom-ce-extensions resolves extension dependencies through a Kotlin class
-            // (net.minestom.dependencies.maven.MavenRepository); without the Kotlin stdlib on the
-            // classpath ExtensionBootstrap init fails with NoClassDefFoundError on kotlin/jvm/internal/Intrinsics.
-            library("kotlin-stdlib-jdk8", "org.jetbrains.kotlin", "kotlin-stdlib-jdk8").versionRef("kotlin")
+            // OneLiteFeather fork of the archived hollow-cube/minestom-ce-extensions. Same
+            // packages (net.hollowcube.minestom.extensions, net.minestom.server.extensions), but
+            // extension dependencies resolve through Maven Resolver instead of the Kotlin-based
+            // DependencyGetter, so no Kotlin stdlib is needed on the class path anymore.
+            library("minestom-extensions-bom", "net.onelitefeather", "minestom-extensions-bom").versionRef("minestom-extensions")
+            library("minestom-extensions", "net.onelitefeather", "minestom-extensions").withoutVersion()
             library("adventure", "net.kyori", "adventure-text-minimessage").withoutVersion()
             library("cyano", "net.onelitefeather", "cyano").withoutVersion()
             library("guira", "net.onelitefeather", "guira").withoutVersion()

--- a/setup/build.gradle.kts
+++ b/setup/build.gradle.kts
@@ -29,8 +29,8 @@ dependencies {
     // CloudNet is provided by the CloudNet wrapper at runtime and its bridge is loaded as a
     // Minestom extension (separate classloader, see the :bridge module), so :setup neither
     // references nor bundles any CloudNet artifact.
-    implementation(libs.minestom.ce.extensions)
-    implementation(libs.kotlin.stdlib.jdk8)
+    implementation(platform(libs.minestom.extensions.bom))
+    implementation(libs.minestom.extensions)
 
     // LuckPerms
     implementation(libs.guava)

--- a/setup/src/main/java/net/onelitefeather/cygnus/setup/SetupLoader.java
+++ b/setup/src/main/java/net/onelitefeather/cygnus/setup/SetupLoader.java
@@ -9,7 +9,7 @@ import net.onelitefeather.cygnus.setup.player.SetupPlayerProvider;
 public class SetupLoader {
 
     static void main() {
-        // minestom-ce-extensions loads platform extensions - the CloudNet bridge and our
+        // minestom-extensions loads platform extensions - the CloudNet bridge and our
         // :bridge permission extension among them - from the extensions/ folder. Running
         // standalone simply loads none. This also performs MinecraftServer.init().
         ExtensionBootstrap bootstrap = ExtensionBootstrap.init();


### PR DESCRIPTION
Replaces the archived `dev.hollowcube:minestom-ce-extensions:1.2.0` with the maintained OneLiteFeather fork, `net.onelitefeather:minestom-extensions:2.1.1`.

## Changes

- `settings.gradle.kts`: catalog entries switched to the fork, wired through `minestom-extensions-bom` so `:game`, `:setup` and `:bridge` cannot drift apart.
- Repository `https://repo.onelitefeather.dev/releases` added. Unlike the `onelitefeather` repository it needs no credentials, so it is declared separately and a fresh clone resolves it.
- `kotlin-stdlib-jdk8` and the `kotlin` version dropped from the catalog and from `:game` / `:setup`. It only existed because the old extension system resolved dependencies through a Kotlin class and `ExtensionBootstrap.init()` died with `NoClassDefFoundError: kotlin/jvm/internal/Intrinsics` without it. The fork uses Apache Maven Resolver, so the workaround is gone — the fat jar now contains zero Kotlin classes.
- No API migration: the fork keeps `net.hollowcube.minestom.extensions.ExtensionBootstrap` and `net.minestom.server.extensions.Extension`. Only two stale comments in `CygnusLoader` / `SetupLoader` were updated.
- `:bridge` now generates `extension.json` from the fork's `@ExtensionInfo` annotation (second commit). The processor validates the entrypoint and the extension name against the runtime's own rules; the hand-written resource and its `@version@` token filtering are gone, the version arrives via `-Aminestom.extension.version`. Retention is `SOURCE`, so the annotation never reaches the jar.
- The JitPack proxy repository stays; the `canis` catalog entry still resolves from `com.github.*`. Its comment was corrected.

The fork requires Java 25+, which the project's toolchain already targets.

## Verification

- `./gradlew build` including tests passes (baseline before the change was green as well).
- Standalone `java -jar cygnus.jar`: `ExtensionBootstrap.init()` completes and LuckPerms loads. The run then stops at `No maps found in the given path` because the scratch directory had no map — unrelated to this change.
- Extension discovery checked explicitly against the shaded `cygnus.jar` with `bridge.jar` in `extensions/`: the extension is discovered, `extension.json` is parsed, the dependency check fires (`requires an extension called CloudNet_Bridge` → skipped locally, exactly as `docs/cloudnet-deployment.md` describes), and the server binds and shuts down cleanly. Behaviour is identical to 1.2.0.
- Re-run after the `@ExtensionInfo` switch: same result. The generated descriptor is byte-for-byte the one the runtime saw before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXYFWh4qqQMzhMkhx1PsGy

