### PR TITLE
fix(stamina): optimize stamina regeneration and consumption check

### DIFF
--- a/game/src/main/java/net/onelitefeather/cygnus/listener/game/PlayerStartSprintingListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/game/PlayerStartSprintingListener.java
@@ -28,11 +28,14 @@ public final class PlayerStartSprintingListener implements Consumer<PlayerStartS
 
         if (cygnusPlayer.hasBlockedSprinting()) {
             event.setCancelled(true);
+            return;
         }
 
         FoodBar staminaBarRef = staminaFunction.apply(player);
         if (!staminaBarRef.canConsume()) {
             event.setCancelled(true);
+            return;
         }
+        staminaBarRef.startConsume();
     }
 }

--- a/game/src/main/java/net/onelitefeather/cygnus/stamina/FoodBar.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/stamina/FoodBar.java
@@ -6,24 +6,47 @@ import net.onelitefeather.cygnus.player.CygnusPlayer;
 
 import java.time.temporal.ChronoUnit;
 
+/**
+ * Represents the stamina bar implementation based on the player's food level and experience bar.
+ * <p>
+ * Manages the consumption and regeneration of stamina when a survivor sprints.
+ * When stamina is depleted, sprinting is temporarily blocked until sufficient stamina
+ * has regenerated.
+ * </p>
+ *
+ * @author theEvilReaper
+ * @version 1.2.0
+ * @since 1.0.0
+ */
 public non-sealed class FoodBar extends StaminaBar {
 
     private static final int MAX_FOOD = 20;
     private static final int FOOD_TAKE = 2;
     private float currentSpeedCount;
 
+    /**
+     * Creates a new instance of the {@link FoodBar} for the specific player
+     *
+     * @param player who owns the bar
+     */
     FoodBar(CygnusPlayer player) {
         super(player, ChronoUnit.MILLIS, 1000);
         state = State.READY;
         this.currentSpeedCount = MAX_FOOD;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected void onStart() {
         this.state = State.READY;
         this.player.setExp(normalize(this.currentSpeedCount));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void consume() {
         if (state == State.READY) return;
@@ -55,30 +78,38 @@ public non-sealed class FoodBar extends StaminaBar {
      * Handles the food regeneration for the player.
      */
     private void handleFoodRegeneration() {
+        this.currentSpeedCount = Math.min(MAX_FOOD, this.currentSpeedCount + 1);
+        player.setExp(normalize(this.currentSpeedCount));
+
         if (this.currentSpeedCount >= MAX_FOOD) {
             state = State.READY;
             player.setBlockedSprinting(false);
-            return;
-        }
-
-        if (this.currentSpeedCount < MAX_FOOD) {
-            ++this.currentSpeedCount;
-            player.setExp(normalize(this.currentSpeedCount));
         }
     }
 
+    /**
+     * Normalizes the current food value to a percentage between {@code 0.0f} and {@code 1.0f}
+     * for display on the player's experience bar.
+     *
+     * @param current the current food value to normalize
+     * @return the normalized value clamped to a minimum of {@code 0.0f}
+     */
     private float normalize(float current) {
-        var newValue = (current) / MAX_FOOD;
-        if (newValue >= 0) {
-            return newValue;
-        }
-        return 0;
+        return Math.max(0.0f, current / MAX_FOOD);
     }
 
+    /**
+     * Returns an indication state if the bar could be consumed.
+     *
+     * @return true for yes otherwise false
+     */
     public boolean canConsume() {
-        return (state == State.READY) || (state == State.DRAINING && currentSpeedCount > 7D);
+        return (state == State.READY) || (state == State.DRAINING) || (state == State.REGENERATING && currentSpeedCount > 7D);
     }
 
+    /**
+     * Set's the internal {@link State} to draining which starts the tick loop
+     */
     public void startConsume() {
         state = State.DRAINING;
     }

--- a/game/src/main/java/net/onelitefeather/cygnus/stamina/FoodBar.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/stamina/FoodBar.java
@@ -55,7 +55,7 @@ public non-sealed class FoodBar extends StaminaBar {
      * Handles the food regeneration for the player.
      */
     private void handleFoodRegeneration() {
-        if (this.currentSpeedCount == MAX_FOOD) {
+        if (this.currentSpeedCount >= MAX_FOOD) {
             state = State.READY;
             player.setBlockedSprinting(false);
             return;
@@ -76,16 +76,11 @@ public non-sealed class FoodBar extends StaminaBar {
     }
 
     public boolean canConsume() {
-        if (state == State.READY) {
-            state = State.DRAINING;
-            return true;
-        }
-        if (state == State.REGENERATING && currentSpeedCount > 7D) {
-            state = State.DRAINING;
-            return true;
-        }
+        return (state == State.READY) || (state == State.DRAINING && currentSpeedCount > 7D);
+    }
 
-        return false;
+    public void startConsume() {
+        state = State.DRAINING;
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

Fixed the state check in `FoodBar.canConsume()`to allow players to resume sprinting during stamina regeneration once above the threshold. Refactored `handleFoodRegeneration()` to eliminate redundant branch checks and enable immediate transition to `State.READY`. Added comprehensive Javadoc documentation for the `FoodBar` class and its `normalize()` method.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the CONTRIBUTING.md
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
