### PR TITLE
fix(map): change instance unregister to avoid exception throw

### DIFF
--- a/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
@@ -195,6 +195,7 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
                     gameMapProvider.getGameMap(),
                     activeInstance
             );
+            gameMapProvider.releasePreviousInstance();
         };
         LobbyPhase lobbyPhase = new LobbyPhase(this.gameConfig);
         this.linearPhaseSeries.add(lobbyPhase);

--- a/game/src/main/java/net/onelitefeather/cygnus/map/GameMapProvider.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/map/GameMapProvider.java
@@ -25,6 +25,7 @@ public final class GameMapProvider extends AbstractMapProvider {
     private final List<FalcoAnvilLoader> chunkLoaders;
     private @Nullable InstanceContainer gameInstance;
     private @Nullable GameMap gameMap;
+    private @Nullable InstanceContainer previousInstance;
 
     public GameMapProvider(Path path) {
         super(GsonHelper.FILE_HANDLER, MapFilters::filterMapsForGame);
@@ -53,14 +54,34 @@ public final class GameMapProvider extends AbstractMapProvider {
         EventDispatcher.call(new GameMapLoadedEvent(this.gameMap, this.gameInstance));
     }
 
+    /**
+     * Switches the provider over to the game map.
+     *
+     * <p>This only moves the active references; the lobby instance stays registered so the players
+     * can still be moved out of it. Call {@link #releasePreviousInstance()} once they are gone.</p>
+     *
+     * @throws IllegalStateException if the game map has not been loaded yet
+     */
     public void switchToGameMap() {
-        if (this.activeInstance != null) {
-            MinecraftServer.getInstanceManager().unregisterInstance(this.activeInstance);
-            this.activeInstance = null;
-            this.activeMap = null;
+        if (this.gameInstance == null || this.gameMap == null) {
+            throw new IllegalStateException("The game map has not been loaded yet");
         }
+        this.previousInstance = this.activeInstance;
         this.activeInstance = this.gameInstance;
         this.activeMap = this.gameMap;
+    }
+
+    /**
+     * Unregisters the instance the provider was on before the last switch.
+     *
+     * <p>Minestom refuses to unregister an instance that still holds online players, so this must
+     * run after every player has been moved into the new instance. Calling it more than once, or
+     * without a previous switch, does nothing.</p>
+     */
+    public void releasePreviousInstance() {
+        if (this.previousInstance == null) return;
+        MinecraftServer.getInstanceManager().unregisterInstance(this.previousInstance);
+        this.previousInstance = null;
     }
 
     private BaseMap loadLobbyMap() {

--- a/game/src/main/java/net/onelitefeather/cygnus/phase/WaitingPhase.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/phase/WaitingPhase.java
@@ -36,11 +36,11 @@ public final class WaitingPhase extends TimedPhase {
     public void onStart() {
         super.onStart();
         EventDispatcher.call(new GamePreLaunchEvent());
+        this.instanceSwitch.apply();
     }
 
     @Override
     protected void onFinish() {
-        this.instanceSwitch.apply();
         this.gameView.addPlayers(new HashSet<>(MinecraftServer.getConnectionManager().getOnlinePlayers()));
     }
 

--- a/game/src/main/java/net/onelitefeather/cygnus/team/TeamHelper.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/team/TeamHelper.java
@@ -119,7 +119,7 @@ public final class TeamHelper {
     private static Set<Player> collectSurvivors(Player slenderPlayer) {
         Set<Player> survivors = new HashSet<>();
         for (Player player : MinecraftServer.getConnectionManager().getOnlinePlayers()) {
-            if (!player.getUuid().equals(slenderPlayer.getUuid())) {
+            if (slenderPlayer == null || !player.getUuid().equals(slenderPlayer.getUuid())) {
                 survivors.add(player);
             }
         }
@@ -239,6 +239,10 @@ public final class TeamHelper {
      * @param position the new position
      */
     private static void updateInstance(Player player, Instance instance, Pos position) {
+        if (instance.equals(player.getInstance())) {
+            player.teleport(position);
+            return;
+        }
         player.setInstance(instance, position);
     }
 

--- a/game/src/test/java/net/onelitefeather/cygnus/map/GameMapSwitchOrderIntegrationTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/map/GameMapSwitchOrderIntegrationTest.java
@@ -1,0 +1,147 @@
+package net.onelitefeather.cygnus.map;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.InstanceContainer;
+import net.minestom.testing.Env;
+import net.minestom.testing.extension.MicrotusExtension;
+import net.onelitefeather.cygnus.common.config.GameConfig;
+import net.onelitefeather.cygnus.common.map.GameMap;
+import net.onelitefeather.cygnus.common.util.GsonHelper;
+import net.onelitefeather.cygnus.team.TeamHelper;
+import net.theevilreaper.aves.map.BaseMap;
+import net.theevilreaper.xerus.api.team.Team;
+import net.theevilreaper.xerus.api.team.TeamService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MicrotusExtension.class)
+class GameMapSwitchOrderIntegrationTest {
+
+    private static final String ARENA_NAME = "arena";
+    private static final Pos LOBBY_SPAWN = Pos.ZERO;
+    private static final Pos SLENDER_SPAWN = new Pos(1, 1, 1);
+    private static final Pos SURVIVOR_SPAWN = new Pos(2, 2, 2);
+
+    @Test
+    void testTeleportAfterSwitchMovesEveryoneIntoTheGameInstance(Env env, @TempDir Path root) throws IOException {
+        GameMapProvider provider = createProvider(root);
+        InstanceContainer lobbyInstance = (InstanceContainer) provider.getActiveInstance().get();
+        provider.loadGameMap();
+
+        Player slender = env.createPlayer(lobbyInstance, LOBBY_SPAWN);
+        Player survivor = env.createPlayer(lobbyInstance, LOBBY_SPAWN);
+        TeamService teamService = createTeamService();
+        teamService.getTeam(GameConfig.SLENDER_KEY).orElseThrow().addPlayer(slender);
+        teamService.getTeam(GameConfig.SURVIVOR_KEY).orElseThrow().addPlayers(Set.of(survivor));
+
+        provider.switchToGameMap();
+        InstanceContainer gameInstance = (InstanceContainer) provider.getActiveInstance().get();
+        assertNotSame(lobbyInstance, gameInstance);
+
+        TeamHelper.teleportTeams(teamService, provider.getGameMap(), gameInstance);
+        for (int i = 0; i < 10; i++) {
+            env.tick();
+        }
+        assertSame(gameInstance, slender.getInstance());
+        assertSame(gameInstance, survivor.getInstance());
+        assertEquals(SLENDER_SPAWN, slender.getPosition());
+
+        assertDoesNotThrow(provider::releasePreviousInstance);
+        assertFalse(MinecraftServer.getInstanceManager().getInstances().contains(lobbyInstance));
+
+        provider.close();
+        env.destroyInstance(gameInstance, true);
+    }
+
+    @Test
+    void testSwitchWithoutLoadedGameMapThrows(Env env, @TempDir Path root) throws IOException {
+        GameMapProvider provider = createProvider(root);
+        InstanceContainer lobbyInstance = (InstanceContainer) provider.getActiveInstance().get();
+
+        assertThrows(IllegalStateException.class, provider::switchToGameMap);
+
+        provider.close();
+        env.destroyInstance(lobbyInstance, true);
+    }
+
+    @Test
+    void testReleaseIsRepeatable(Env env, @TempDir Path root) throws IOException {
+        GameMapProvider provider = createProvider(root);
+        InstanceContainer lobbyInstance = (InstanceContainer) provider.getActiveInstance().get();
+        provider.loadGameMap();
+        provider.switchToGameMap();
+
+        InstanceContainer gameInstance = (InstanceContainer) provider.getActiveInstance().get();
+
+        assertDoesNotThrow(provider::releasePreviousInstance);
+        assertDoesNotThrow(provider::releasePreviousInstance);
+
+        provider.close();
+        env.destroyInstance(gameInstance, true);
+    }
+
+    @Test
+    void testUpdateInstanceWithinSameInstanceTeleports(Env env, @TempDir Path root) throws IOException {
+        GameMapProvider provider = createProvider(root);
+        provider.loadGameMap();
+        provider.switchToGameMap();
+
+        InstanceContainer gameInstance = (InstanceContainer) provider.getActiveInstance().get();
+        Player slender = env.createPlayer(gameInstance, LOBBY_SPAWN);
+        Player survivor = env.createPlayer(gameInstance, LOBBY_SPAWN);
+
+        TeamService teamService = createTeamService();
+        teamService.getTeam(GameConfig.SLENDER_KEY).orElseThrow().addPlayer(slender);
+        teamService.getTeam(GameConfig.SURVIVOR_KEY).orElseThrow().addPlayers(Set.of(survivor));
+
+        assertDoesNotThrow(() -> TeamHelper.teleportTeams(teamService, provider.getGameMap(), gameInstance));
+        assertEquals(SLENDER_SPAWN, slender.getPosition());
+
+        provider.close();
+        env.destroyInstance(gameInstance, true);
+    }
+
+    private TeamService createTeamService() {
+        TeamService teamService = TeamService.of();
+        teamService.add(Team.of(GameConfig.SLENDER_KEY, 1));
+        teamService.add(Team.of(GameConfig.SURVIVOR_KEY, 10));
+        teamService.add(Team.of(GameConfig.SPECTATOR_KEY, 10));
+        return teamService;
+    }
+
+    private GameMapProvider createProvider(Path root) throws IOException {
+        Path maps = root.resolve("game").resolve("maps");
+        writeMap(maps.resolve("lobby"), new BaseMap("lobby", LOBBY_SPAWN, List.of()), false);
+        writeMap(
+                maps.resolve(ARENA_NAME),
+                new GameMap(ARENA_NAME, LOBBY_SPAWN, SLENDER_SPAWN, Set.of(), Set.of(SURVIVOR_SPAWN), List.of()),
+                true
+        );
+        return new GameMapProvider(root);
+    }
+
+    private void writeMap(Path directoryRoot, BaseMap map, boolean dimensionLayout) throws IOException {
+        Path regionDirectory = dimensionLayout
+                ? directoryRoot.resolve("dimensions").resolve("minecraft").resolve("overworld").resolve("region")
+                : directoryRoot.resolve("region");
+        Files.createDirectories(regionDirectory);
+        Files.writeString(directoryRoot.resolve("map.json"), GsonHelper.GSON.toJson(map), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## Proposed changes

Minestom does not allow an instance to be unregistered while players are still present in it. This pull request fixes the unregister logic by ensuring instances are only unregistered after all players have been removed.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)