### PR TITLE
chore(team): remove old team id approach

### DIFF
--- a/common/src/main/java/net/onelitefeather/cygnus/common/Tags.java
+++ b/common/src/main/java/net/onelitefeather/cygnus/common/Tags.java
@@ -1,5 +1,6 @@
 package net.onelitefeather.cygnus.common;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.tag.Tag;
 
 import java.util.UUID;
@@ -8,17 +9,17 @@ import java.util.UUID;
  * The {@link Tags} class contains all tags used in the project. It is a utility class and should not be instantiated.
  *
  * @author theEvilReaper
- * @version 1.0.1
+ * @version 1.1.0
  * @since 1.0.0
  **/
 public final class Tags {
 
     public static final Tag<UUID> PAGE_TAG = Tag.UUID("page");
-
     public static final Tag<Byte> ITEM_TAG = Tag.Byte("itemTag");
-    public static final Tag<Byte> TEAM_ID = Tag.Byte("team");
+    public static final Tag<Key> TEAM_KEY = Tag.Transient("teamKey");
     public static final Tag<Byte> HIDDEN = Tag.Byte("hidden");
 
     private Tags() {
+        // Nothing do to here
     }
 }

--- a/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
@@ -213,6 +213,6 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
     }
 
     private void triggerViewRuleUpdate(@NotNull Player player) {
-        ViewRuleUpdater.updateViewer(player, this.teamService.getTeams().get(TeamHelper.SURVIVOR_TEAM_ID));
+        ViewRuleUpdater.updateViewer(player, this.teamService.getTeam(GameConfig.SURVIVOR_KEY).orElseThrow());
     }
 }

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerDeathListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerDeathListener.java
@@ -48,7 +48,7 @@ public final class PlayerDeathListener implements Consumer<PlayerDeathEvent> {
 
         event.setChatMessage(Messages.getDeathComponent(player));
         survivorTeam.removePlayer(player);
-        player.removeTag(Tags.TEAM_ID);
+        player.removeTag(Tags.TEAM_KEY);
         EventDispatcher.call(new SpectatorAddEvent(player));
         Phase currentPhase = this.phaseSupplier.get();
         //TODO: Should be tested

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerQuitListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerQuitListener.java
@@ -102,9 +102,9 @@ public final class PlayerQuitListener implements Consumer<PlayerDisconnectEvent>
      * @param gamePhase the active game phase
      */
     private void handleInGameQuit(Player player, GamePhase gamePhase) {
-        if (!player.hasTag(Tags.TEAM_ID)) return;
-        byte teamID = player.getTag(Tags.TEAM_ID);
-        Optional<Team> teamOpt = teamService.getTeam(TeamHelper.keyForTeamId(teamID));
+        if (!player.hasTag(Tags.TEAM_KEY)) return;
+        net.kyori.adventure.key.Key teamKey = player.getTag(Tags.TEAM_KEY);
+        Optional<Team> teamOpt = teamService.getTeam(teamKey);
 
         if (teamOpt.isEmpty()) return;
         Team team = teamOpt.get();

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerQuitListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerQuitListener.java
@@ -1,5 +1,6 @@
 package net.onelitefeather.cygnus.listener;
 
+import net.kyori.adventure.key.Key;
 import net.theevilreaper.aves.util.Broadcaster;
 import net.theevilreaper.aves.util.Players;
 import net.theevilreaper.xerus.api.phase.Phase;
@@ -103,7 +104,7 @@ public final class PlayerQuitListener implements Consumer<PlayerDisconnectEvent>
      */
     private void handleInGameQuit(Player player, GamePhase gamePhase) {
         if (!player.hasTag(Tags.TEAM_KEY)) return;
-        net.kyori.adventure.key.Key teamKey = player.getTag(Tags.TEAM_KEY);
+        Key teamKey = player.getTag(Tags.TEAM_KEY);
         Optional<Team> teamOpt = teamService.getTeam(teamKey);
 
         if (teamOpt.isEmpty()) return;

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerSpawnListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerSpawnListener.java
@@ -41,7 +41,7 @@ public final class PlayerSpawnListener implements Consumer<PlayerSpawnEvent> {
             return;
         }
 
-        var tag = player.getTag(Tags.TEAM_ID);
+        var tag = player.getTag(Tags.TEAM_KEY);
 
         if (tag == null) {
             this.spawnSupplier.accept(player);

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/game/PlayerStartSprintingListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/game/PlayerStartSprintingListener.java
@@ -21,7 +21,7 @@ public final class PlayerStartSprintingListener implements Consumer<PlayerStartS
     @Override
     public void accept(PlayerStartSprintingEvent event) {
         var player = event.getPlayer();
-        if (!player.hasTag(Tags.TEAM_ID)) return;
+        if (!player.hasTag(Tags.TEAM_KEY)) return;
         if (TeamHelper.isSlenderTeam(player)) return;
 
         CygnusPlayer cygnusPlayer = (CygnusPlayer) player;

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/game/PlayerStopSprintingListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/game/PlayerStopSprintingListener.java
@@ -20,7 +20,7 @@ public class PlayerStopSprintingListener implements Consumer<PlayerStopSprinting
     @Override
     public void accept(PlayerStopSprintingEvent event) {
         var player = event.getPlayer();
-        if (!player.hasTag(Tags.TEAM_ID)) return;
+        if (!player.hasTag(Tags.TEAM_KEY)) return;
         if (!TeamHelper.isSurvivorTeam(player)) return;
 
         FoodBar staminaBarRef = staminaFunction.apply(player);

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/game/SlenderReviveListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/game/SlenderReviveListener.java
@@ -32,7 +32,7 @@ public class SlenderReviveListener implements Consumer<SlenderReviveEvent> {
     public void accept(SlenderReviveEvent event) {
         Player player = event.getPlayer();
         staminaService.setSlenderBar(player, true);
-        player.setTag(Tags.TEAM_ID, TeamHelper.SLENDER_TEAM_ID);
+        player.setTag(Tags.TEAM_KEY, net.onelitefeather.cygnus.common.config.GameConfig.SLENDER_KEY);
         GameMap gameMap = gameMapSupplier.get();
         if (gameMap != null && gameMap.getSlenderSpawn() != null) {
             player.teleport(gameMap.getSlenderSpawn());

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/game/SlenderReviveListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/game/SlenderReviveListener.java
@@ -2,6 +2,7 @@ package net.onelitefeather.cygnus.listener.game;
 
 import net.minestom.server.entity.Player;
 import net.onelitefeather.cygnus.common.Tags;
+import net.onelitefeather.cygnus.common.config.GameConfig;
 import net.onelitefeather.cygnus.common.map.GameMap;
 import net.onelitefeather.cygnus.event.SlenderReviveEvent;
 import net.onelitefeather.cygnus.stamina.StaminaService;
@@ -32,7 +33,7 @@ public class SlenderReviveListener implements Consumer<SlenderReviveEvent> {
     public void accept(SlenderReviveEvent event) {
         Player player = event.getPlayer();
         staminaService.setSlenderBar(player, true);
-        player.setTag(Tags.TEAM_KEY, net.onelitefeather.cygnus.common.config.GameConfig.SLENDER_KEY);
+        player.setTag(Tags.TEAM_KEY, GameConfig.SLENDER_KEY);
         GameMap gameMap = gameMapSupplier.get();
         if (gameMap != null && gameMap.getSlenderSpawn() != null) {
             player.teleport(gameMap.getSlenderSpawn());

--- a/game/src/main/java/net/onelitefeather/cygnus/spectator/SpectatorService.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/spectator/SpectatorService.java
@@ -54,7 +54,7 @@ public final class SpectatorService {
      */
     public void join(Player player) {
         player.setGameMode(GameMode.SPECTATOR);
-        player.setTag(Tags.TEAM_ID, TeamHelper.SPECTATOR_TEAM_ID);
+        player.setTag(Tags.TEAM_KEY, net.onelitefeather.cygnus.common.config.GameConfig.SPECTATOR_KEY);
         spectatorTeam.addPlayer(player);
         Items.setSpectatorLayout(player);
         player.updateViewableRule(_ -> false);

--- a/game/src/main/java/net/onelitefeather/cygnus/spectator/SpectatorService.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/spectator/SpectatorService.java
@@ -8,6 +8,7 @@ import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.player.PlayerUseItemEvent;
 import net.onelitefeather.cygnus.common.Tags;
+import net.onelitefeather.cygnus.common.config.GameConfig;
 import net.onelitefeather.cygnus.player.event.SpectatorAddEvent;
 import net.onelitefeather.cygnus.player.listener.SpectatorAddListener;
 import net.onelitefeather.cygnus.player.listener.SpectatorItemListener;
@@ -54,7 +55,7 @@ public final class SpectatorService {
      */
     public void join(Player player) {
         player.setGameMode(GameMode.SPECTATOR);
-        player.setTag(Tags.TEAM_KEY, net.onelitefeather.cygnus.common.config.GameConfig.SPECTATOR_KEY);
+        player.setTag(Tags.TEAM_KEY, GameConfig.SPECTATOR_KEY);
         spectatorTeam.addPlayer(player);
         Items.setSpectatorLayout(player);
         player.updateViewableRule(_ -> false);

--- a/game/src/main/java/net/onelitefeather/cygnus/team/TeamHelper.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/team/TeamHelper.java
@@ -30,37 +30,6 @@ import java.util.Set;
 public final class TeamHelper {
 
     /**
-     * The ID representing the Slender team.
-     */
-    public static final byte SLENDER_TEAM_ID = 0;
-
-    /**
-     * The ID representing the Survivor team.
-     */
-    public static final byte SURVIVOR_TEAM_ID = 1;
-
-    /**
-     * The ID representing the Spectator team.
-     */
-    public static final byte SPECTATOR_TEAM_ID = 2;
-
-    /**
-     * Resolves the {@link Key} a numeric team ID tag value refers to.
-     *
-     * @param id the team ID (see {@link Tags#TEAM_ID})
-     * @return the team's key
-     * @throws IllegalArgumentException if the ID does not name a known team
-     */
-    public static Key keyForTeamId(byte id) {
-        return switch (id) {
-            case SLENDER_TEAM_ID -> GameConfig.SLENDER_KEY;
-            case SURVIVOR_TEAM_ID -> GameConfig.SURVIVOR_KEY;
-            case SPECTATOR_TEAM_ID -> GameConfig.SPECTATOR_KEY;
-            default -> throw new IllegalArgumentException("Unknown team ID: " + id);
-        };
-    }
-
-    /**
      * Result of a team allocation, containing the chosen slender player and the resulting survivors.
      *
      * @param slender   the player who is the slender
@@ -105,7 +74,7 @@ public final class TeamHelper {
      * @param slenderTeam the team to add the player to
      */
     private static void assignSlender(Player player, Team slenderTeam) {
-        player.setTag(Tags.TEAM_ID, SLENDER_TEAM_ID);
+        player.setTag(Tags.TEAM_KEY, GameConfig.SLENDER_KEY);
         player.updateViewableRule(ViewRuleUpdater::viewableRuleForSlender);
         slenderTeam.addPlayer(player);
     }
@@ -133,7 +102,7 @@ public final class TeamHelper {
      * @param survivorTeam the team to add them to
      */
     private static void assignSurvivors(Set<Player> survivors, Team survivorTeam) {
-        survivors.forEach(player -> player.setTag(Tags.TEAM_ID, SURVIVOR_TEAM_ID));
+        survivors.forEach(player -> player.setTag(Tags.TEAM_KEY, GameConfig.SURVIVOR_KEY));
         survivorTeam.addPlayers(survivors);
     }
 
@@ -205,8 +174,7 @@ public final class TeamHelper {
      * @return true if the player is in the slender team
      */
     public static boolean isSlenderTeam(Player player) {
-        Byte teamId = player.getTag(Tags.TEAM_ID);
-        return teamId != null && teamId == SLENDER_TEAM_ID;
+        return GameConfig.SLENDER_KEY.equals(player.getTag(Tags.TEAM_KEY));
     }
 
     /**
@@ -216,8 +184,7 @@ public final class TeamHelper {
      * @return true if the player is in the survivor team
      */
     public static boolean isSurvivorTeam(Player player) {
-        Byte teamId = player.getTag(Tags.TEAM_ID);
-        return teamId != null && teamId == SURVIVOR_TEAM_ID;
+        return GameConfig.SURVIVOR_KEY.equals(player.getTag(Tags.TEAM_KEY));
     }
 
     /**
@@ -227,8 +194,7 @@ public final class TeamHelper {
      * @return true if the player is in the spectator team
      */
     public static boolean isSpectatorTeam(Player player) {
-        Byte teamId = player.getTag(Tags.TEAM_ID);
-        return teamId != null && teamId == SPECTATOR_TEAM_ID;
+        return GameConfig.SPECTATOR_KEY.equals(player.getTag(Tags.TEAM_KEY));
     }
 
     /**

--- a/game/src/main/java/net/onelitefeather/cygnus/utils/ScoreboardDisplay.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/utils/ScoreboardDisplay.java
@@ -51,34 +51,38 @@ public final class ScoreboardDisplay {
     /**
      * Add a player to a team
      *
-     * @param player the player to add
-     * @param teamId the team id to add the player to
+     * @param player  the player to add
+     * @param teamKey the key of the team to add the player to
      */
-    public void addPlayer(Player player, byte teamId) {
-        var teamName = getTeamName(teamId);
+    public void addPlayer(Player player, net.kyori.adventure.key.Key teamKey) {
+        var teamName = getTeamName(teamKey);
         var team = MinecraftServer.getTeamManager().getTeam(teamName);
-        team.addMember(player.getUsername());
+        if (team != null) {
+            team.addMember(player.getUsername());
+        }
     }
 
     /**
      * Remove a player from a team
      *
-     * @param player the player to remove
-     * @param teamId the team id to remove the player from
+     * @param player  the player to remove
+     * @param teamKey the key of the team to remove the player from
      */
-    public void removePlayer(Player player, byte teamId) {
-        var teamName = getTeamName(teamId);
+    public void removePlayer(Player player, net.kyori.adventure.key.Key teamKey) {
+        var teamName = getTeamName(teamKey);
         var team = MinecraftServer.getTeamManager().getTeam(teamName);
-        team.removeMember(player.getUsername());
+        if (team != null) {
+            team.removeMember(player.getUsername());
+        }
     }
 
     /**
-     * Get the team name by the team id
+     * Get the team name by the team key
      *
-     * @param teamId the team id
+     * @param teamKey the team key
      * @return the team name
      */
-    private String getTeamName(byte teamId) {
-        return teamId == TeamHelper.SLENDER_TEAM_ID ? GameConfig.SLENDER_TEAM_NAME : GameConfig.SURVIVOR_TEAM_NAME;
+    private String getTeamName(net.kyori.adventure.key.Key teamKey) {
+        return GameConfig.SLENDER_KEY.equals(teamKey) ? GameConfig.SLENDER_TEAM_NAME : GameConfig.SURVIVOR_TEAM_NAME;
     }
 }

--- a/game/src/main/java/net/onelitefeather/cygnus/utils/ScoreboardDisplay.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/utils/ScoreboardDisplay.java
@@ -1,5 +1,6 @@
 package net.onelitefeather.cygnus.utils;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.color.TeamColor;
 import net.onelitefeather.cygnus.component.TeamNameComponent;
 import net.theevilreaper.xerus.api.ColorData;
@@ -54,7 +55,7 @@ public final class ScoreboardDisplay {
      * @param player  the player to add
      * @param teamKey the key of the team to add the player to
      */
-    public void addPlayer(Player player, net.kyori.adventure.key.Key teamKey) {
+    public void addPlayer(Player player, Key teamKey) {
         var teamName = getTeamName(teamKey);
         var team = MinecraftServer.getTeamManager().getTeam(teamName);
         if (team != null) {
@@ -68,7 +69,7 @@ public final class ScoreboardDisplay {
      * @param player  the player to remove
      * @param teamKey the key of the team to remove the player from
      */
-    public void removePlayer(Player player, net.kyori.adventure.key.Key teamKey) {
+    public void removePlayer(Player player, Key teamKey) {
         var teamName = getTeamName(teamKey);
         var team = MinecraftServer.getTeamManager().getTeam(teamName);
         if (team != null) {
@@ -82,7 +83,7 @@ public final class ScoreboardDisplay {
      * @param teamKey the team key
      * @return the team name
      */
-    private String getTeamName(net.kyori.adventure.key.Key teamKey) {
+    private String getTeamName(Key teamKey) {
         return GameConfig.SLENDER_KEY.equals(teamKey) ? GameConfig.SLENDER_TEAM_NAME : GameConfig.SURVIVOR_TEAM_NAME;
     }
 }

--- a/game/src/test/java/net/onelitefeather/cygnus/listener/PlayerChatListenerTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/listener/PlayerChatListenerTest.java
@@ -34,7 +34,7 @@ class PlayerChatListenerTest extends CygnusPlayerTestBase {
 
         Team spectatorTeam = Team.of(GameConfig.SPECTATOR_KEY, 5);
         spectatorTeam.addPlayer(spectator);
-        spectator.setTag(Tags.TEAM_ID, TeamHelper.SPECTATOR_TEAM_ID);
+        spectator.setTag(Tags.TEAM_KEY, GameConfig.SPECTATOR_KEY);
 
         GamePhase gamePhase = new GamePhase(new GameViewImpl(), () -> {}, 600, new JumpScareManager());
         PlayerChatListener listener = new PlayerChatListener(spectatorTeam, () -> gamePhase);
@@ -78,7 +78,7 @@ class PlayerChatListenerTest extends CygnusPlayerTestBase {
 
         Team spectatorTeam = Team.of(GameConfig.SPECTATOR_KEY, 5);
         spectatorTeam.addPlayer(spectator);
-        spectator.setTag(Tags.TEAM_ID, TeamHelper.SPECTATOR_TEAM_ID);
+        spectator.setTag(Tags.TEAM_KEY, GameConfig.SPECTATOR_KEY);
 
         GameConfig config = GameConfig.builder().lobbyTime(30).minPlayers(2).gameTime(600).maxPlayers(10).build();
         LobbyPhase lobbyPhase = new LobbyPhase(config);

--- a/game/src/test/java/net/onelitefeather/cygnus/listener/PlayerDeathListenerTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/listener/PlayerDeathListenerTest.java
@@ -31,7 +31,7 @@ class PlayerDeathListenerTest extends CygnusPlayerTestBase {
         teamService.add(survivorTeam);
 
         survivorTeam.addPlayer(player);
-        player.setTag(Tags.TEAM_ID, TeamHelper.SURVIVOR_TEAM_ID);
+        player.setTag(Tags.TEAM_KEY, GameConfig.SURVIVOR_KEY);
 
         PlayerDeathListener listener = new PlayerDeathListener(() -> null, teamService, new JumpScareManager());
 

--- a/game/src/test/java/net/onelitefeather/cygnus/listener/PlayerQuitListenerTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/listener/PlayerQuitListenerTest.java
@@ -42,11 +42,11 @@ class PlayerQuitListenerTest extends CygnusPlayerTestBase {
         teamService.add(spectatorTeam);
 
         slenderTeam.addPlayer(slender);
-        slender.setTag(Tags.TEAM_ID, TeamHelper.SLENDER_TEAM_ID);
+        slender.setTag(Tags.TEAM_KEY, GameConfig.SLENDER_KEY);
         survivorTeam.addPlayer(survivor);
-        survivor.setTag(Tags.TEAM_ID, TeamHelper.SURVIVOR_TEAM_ID);
+        survivor.setTag(Tags.TEAM_KEY, GameConfig.SURVIVOR_KEY);
         spectatorTeam.addPlayer(spectator);
-        spectator.setTag(Tags.TEAM_ID, TeamHelper.SPECTATOR_TEAM_ID);
+        spectator.setTag(Tags.TEAM_KEY, GameConfig.SPECTATOR_KEY);
 
         GamePhase gamePhase = new GamePhase(new GameViewImpl(), () -> {}, 600, new JumpScareManager());
         PlayerQuitListener listener = new PlayerQuitListener(() -> gamePhase, teamService, new StaminaService(), 2);
@@ -80,9 +80,9 @@ class PlayerQuitListenerTest extends CygnusPlayerTestBase {
         teamService.add(spectatorTeam);
 
         slenderTeam.addPlayer(slender);
-        slender.setTag(Tags.TEAM_ID, TeamHelper.SLENDER_TEAM_ID);
+        slender.setTag(Tags.TEAM_KEY, GameConfig.SLENDER_KEY);
         survivorTeam.addPlayer(survivor);
-        survivor.setTag(Tags.TEAM_ID, TeamHelper.SURVIVOR_TEAM_ID);
+        survivor.setTag(Tags.TEAM_KEY, GameConfig.SURVIVOR_KEY);
 
         GamePhase gamePhase = new GamePhase(new GameViewImpl(), () -> {}, 600, new JumpScareManager());
         PlayerQuitListener listener = new PlayerQuitListener(() -> gamePhase, teamService, new StaminaService(), 2);

--- a/game/src/test/java/net/onelitefeather/cygnus/listener/game/SlenderReviveIntegrationTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/listener/game/SlenderReviveIntegrationTest.java
@@ -6,6 +6,7 @@ import net.minestom.testing.Env;
 import net.onelitefeather.cygnus.CygnusPlayerTestBase;
 import net.onelitefeather.cygnus.common.Tags;
 import net.onelitefeather.cygnus.common.map.GameMap;
+import net.onelitefeather.cygnus.common.config.GameConfig;
 import net.onelitefeather.cygnus.event.SlenderReviveEvent;
 import net.onelitefeather.cygnus.player.CygnusPlayer;
 import net.onelitefeather.cygnus.stamina.StaminaService;
@@ -46,7 +47,7 @@ class SlenderReviveIntegrationTest extends CygnusPlayerTestBase {
 
         env.process().eventHandler().call(new SlenderReviveEvent(player));
 
-        assertEquals(TeamHelper.SLENDER_TEAM_ID, player.getTag(Tags.TEAM_ID));
+        assertEquals(GameConfig.SLENDER_KEY, player.getTag(Tags.TEAM_KEY));
         assertEquals(targetSpawn, player.getPosition());
         assertNotNull(staminaService.getSlenderBar());
 

--- a/game/src/test/java/net/onelitefeather/cygnus/spectator/SpectatorServiceTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/spectator/SpectatorServiceTest.java
@@ -34,7 +34,7 @@ class SpectatorServiceTest extends CygnusPlayerTestBase {
 
         assertEquals(GameMode.SPECTATOR, player.getGameMode());
         assertTrue(spectatorTeam.getPlayers().contains(player));
-        assertEquals(TeamHelper.SPECTATOR_TEAM_ID, (byte) player.getTag(Tags.TEAM_ID));
+        assertEquals(GameConfig.SPECTATOR_KEY, player.getTag(Tags.TEAM_KEY));
         assertEquals(Material.COMPASS, player.getInventory().getItemStack(2).material());
         assertEquals(Material.OAK_DOOR, player.getInventory().getItemStack(5).material());
 

--- a/game/src/test/java/net/onelitefeather/cygnus/utils/ScoreboardDisplayTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/utils/ScoreboardDisplayTest.java
@@ -72,17 +72,17 @@ class ScoreboardDisplayTest {
         assertNotNull(scoreboardDisplay);
 
         TeamManager teamManager = env.process().team();
-        scoreboardDisplay.addPlayer(testPlayer, (byte) 0x00);
+        scoreboardDisplay.addPlayer(testPlayer, GameConfig.SLENDER_KEY);
         String rawTeamName = slenderTeam.get(TeamNameComponent.class).teamName();
         assertTrue(teamManager.getTeam(rawTeamName).getMembers().contains(testPlayer.getUsername()));
-        scoreboardDisplay.removePlayer(testPlayer, (byte) 0x00);
+        scoreboardDisplay.removePlayer(testPlayer, GameConfig.SLENDER_KEY);
         assertFalse(teamManager.getTeam(rawTeamName).getMembers().contains(testPlayer.getUsername()));
 
 
-        scoreboardDisplay.addPlayer(testPlayer, (byte) 0x01);
+        scoreboardDisplay.addPlayer(testPlayer, GameConfig.SURVIVOR_KEY);
         rawTeamName = survivorTeam.get(TeamNameComponent.class).teamName();
         assertTrue(teamManager.getTeam(rawTeamName).getMembers().contains(testPlayer.getUsername()));
-        scoreboardDisplay.removePlayer(testPlayer, (byte) 0x01);
+        scoreboardDisplay.removePlayer(testPlayer, GameConfig.SURVIVOR_KEY);
         assertFalse(teamManager.getTeam(rawTeamName).getMembers().contains(testPlayer.getUsername()));
     }
 }

--- a/game/src/test/java/net/onelitefeather/cygnus/utils/TeamHelperTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/utils/TeamHelperTest.java
@@ -54,7 +54,7 @@ class TeamHelperTest {
 
     @AfterEach
     void cleanup() {
-        player.removeTag(Tags.TEAM_ID);
+        player.removeTag(Tags.TEAM_KEY);
         player.setDisplayName(Component.text(player.getUsername()));
     }
 
@@ -187,21 +187,21 @@ class TeamHelperTest {
 
     @Test
     void testIsInSlenderTeam() {
-        player.setTag(Tags.TEAM_ID, TeamHelper.SLENDER_TEAM_ID);
+        player.setTag(Tags.TEAM_KEY, GameConfig.SLENDER_KEY);
         assertTrue(TeamHelper.isSlenderTeam(player));
         assertFalse(TeamHelper.isSurvivorTeam(player));
     }
 
     @Test
     void testIsInSurvivorTeam() {
-        player.setTag(Tags.TEAM_ID, TeamHelper.SURVIVOR_TEAM_ID);
+        player.setTag(Tags.TEAM_KEY, GameConfig.SURVIVOR_KEY);
         assertFalse(TeamHelper.isSlenderTeam(player));
         assertTrue(TeamHelper.isSurvivorTeam(player));
     }
 
     @Test
     void testIsInSpectatorTeam() {
-        player.setTag(Tags.TEAM_ID, TeamHelper.SPECTATOR_TEAM_ID);
+        player.setTag(Tags.TEAM_KEY, GameConfig.SPECTATOR_KEY);
         assertFalse(TeamHelper.isSlenderTeam(player));
         assertFalse(TeamHelper.isSurvivorTeam(player));
         assertTrue(TeamHelper.isSpectatorTeam(player));


### PR DESCRIPTION
## Proposed changes

In older versions of the game, each team was identified by a unique ID. Due to structural changes, this approach is no longer suitable. This pull request replaces team IDs with Adventure keys and updates the implementation accordingly.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)