### PR TITLE
fix(page): improve id determination

### DIFF
--- a/common/src/main/java/net/onelitefeather/cygnus/common/page/PageCreator.java
+++ b/common/src/main/java/net/onelitefeather/cygnus/common/page/PageCreator.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * Creates page items for the game.
  * <p>
  * When custom pages are enabled, a random item model is assigned to the page.
- * The available models range from {@code page_0} up to {@code page_(MAX_CUSTOM_PAGE_ID - 1)}.
+ * Available models are {@code page_1}, {@code page_2}, {@code page_4}, {@code page_5}, and {@code page_6}.
  * If custom pages are disabled, a regular paper item is returned instead.
  *
  * @author theEvilReaper
@@ -24,7 +24,7 @@ public interface PageCreator {
     /**
      * Number of available custom page models.
      */
-    int MAX_CUSTOM_PAGE_ID = 6;
+    int MAX_CUSTOM_PAGE_ID = 5;
 
     /**
      * Creates a page item with the given page number.
@@ -43,7 +43,9 @@ public interface PageCreator {
             return builder.build();
         }
 
-        int randomPage = ThreadLocalRandom.current().nextInt(MAX_CUSTOM_PAGE_ID);
+        int MAX_CUSTOM_PAGE_ID = 6;
+
+        int randomPage = ThreadLocalRandom.current().nextInt(1, MAX_CUSTOM_PAGE_ID + 1);
 
         return builder
                 .set(DataComponents.ITEM_MODEL, Key.key("cygnus", "page_" + randomPage).asString())

--- a/common/src/test/java/net/onelitefeather/cygnus/common/page/PageCreatorTest.java
+++ b/common/src/test/java/net/onelitefeather/cygnus/common/page/PageCreatorTest.java
@@ -25,7 +25,7 @@ class PageCreatorTest {
 
     @Test
     @SetSystemProperty(key = "cygnus.custom_pages", value = "false")
-    void shouldCreateDefaultPageWhenCustomPagesAreDisabled(Env ignored) {
+    void testDefaultPageCreation(Env ignored) {
         boolean useCustomPage = Boolean.parseBoolean(System.getProperty("cygnus.custom_pages"));
         ItemStack page = pageCreator.createPageItem(useCustomPage, 5);
 
@@ -38,14 +38,19 @@ class PageCreatorTest {
 
     @Test
     @SetSystemProperty(key = "cygnus.custom_pages", value = "true")
-    void shouldAssignCustomModelWhenCustomPagesAreEnabled(Env ignored) {
+    void testCustomPageCreation(Env ignored) {
         boolean useCustomPage = Boolean.parseBoolean(System.getProperty("cygnus.custom_pages"));
-        ItemStack page = pageCreator.createPageItem(useCustomPage, 5);
 
-        assertTrue(page.has(DataComponents.ITEM_MODEL));
-        String model = page.get(DataComponents.ITEM_MODEL);
+        for (int i = 0; i < 100; i++) {
+            ItemStack page = pageCreator.createPageItem(useCustomPage, 5);
 
-        assertNotNull(model);
-        assertTrue(model.matches("cygnus:page_[0-5]"));
+            assertEquals(Material.PAPER, page.material());
+            assertTrue(page.has(DataComponents.ITEM_MODEL));
+
+            String model = page.get(DataComponents.ITEM_MODEL);
+
+            assertNotNull(model);
+            assertTrue(model.matches("cygnus:page_[1-6]"));
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Currently, the random custom page ID is generated in the range `[0..5]`, which does not match the resource pack. To avoid missing textures, the range has been updated to `[1..6]`.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)