### PR TITLE
fix(meta): add guard check for the ClientSettingsPacket

### DIFF
--- a/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/Cygnus.java
@@ -34,7 +34,10 @@ import net.minestom.server.event.player.PlayerDisconnectEvent;
 import net.minestom.server.event.player.PlayerEntityInteractEvent;
 import net.minestom.server.event.player.PlayerSpawnEvent;
 import net.minestom.server.event.player.PlayerUseItemEvent;
+import net.minestom.server.entity.EntityType;
 import net.minestom.server.listener.EntityActionListener;
+import net.minestom.server.listener.common.SettingsListener;
+import net.minestom.server.network.packet.client.common.ClientSettingsPacket;
 import net.minestom.server.network.packet.client.play.ClientEntityActionPacket;
 import net.onelitefeather.cygnus.ambient.AmbientProvider;
 import net.onelitefeather.cygnus.command.StartCommand;
@@ -49,6 +52,7 @@ import net.onelitefeather.cygnus.event.GameFinishEvent;
 import net.onelitefeather.cygnus.event.SlenderReviveEvent;
 import net.onelitefeather.cygnus.event.StaminaStateChangeEvent;
 import net.onelitefeather.cygnus.jumpscare.JumpScareManager;
+import net.onelitefeather.cygnus.listener.CygnusSettingsListener;
 import net.onelitefeather.cygnus.listener.PlayerChatListener;
 import net.onelitefeather.cygnus.listener.PlayerDeathListener;
 import net.onelitefeather.cygnus.listener.PlayerLoginListener;
@@ -189,6 +193,7 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
         handler.addListener(PageDiscoveryCompletedEvent.class, new PageDiscoveryCompleteListener(this.linearPhaseSeries));
         handler.addListener(ViewUpdateEvent.class, new ViewUpdateListener(this.view, this.pageProvider));
         MinecraftServer.getPacketListenerManager().setPlayListener(ClientEntityActionPacket.class, CygnusEntityActionListener::listener);
+        MinecraftServer.getPacketListenerManager().setPlayListener(ClientSettingsPacket.class, CygnusSettingsListener::listener);
 
         spectatorService.registerListener(handler);
     }
@@ -220,7 +225,11 @@ public final class Cygnus implements TeamCreator, ListenerHandling {
         this.staminaService.cleanUp();
         this.ambientProvider.stopTask();
         this.jumpscareManager.cleanUp();
+        this.teamService.getTeam(GameConfig.SLENDER_KEY)
+                .ifPresent(slenderTeam -> slenderTeam.getPlayers()
+                        .forEach(player -> player.switchEntityType(EntityType.PLAYER)));
         MinecraftServer.getPacketListenerManager().setPlayListener(ClientEntityActionPacket.class, EntityActionListener::listener);
+        MinecraftServer.getPacketListenerManager().setPlayListener(ClientSettingsPacket.class, SettingsListener::listener);
     }
 
     private void triggerViewRuleUpdate(@NotNull Player player) {

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/CygnusSettingsListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/CygnusSettingsListener.java
@@ -15,7 +15,7 @@ import net.minestom.server.network.packet.client.common.ClientSettingsPacket;
  *
  * @author theEvilReaper
  * @version 1.0.0
- * @since 2.7.1
+ * @since 2.7.0
  */
 public final class CygnusSettingsListener {
 

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/CygnusSettingsListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/CygnusSettingsListener.java
@@ -1,0 +1,31 @@
+package net.onelitefeather.cygnus.listener;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.entity.metadata.avatar.PlayerMeta;
+import net.minestom.server.event.EventDispatcher;
+import net.minestom.server.event.player.PlayerSettingsChangeEvent;
+import net.minestom.server.network.packet.client.common.ClientSettingsPacket;
+
+/**
+ * Replaces Minestom's built-in {@code SettingsListener}. A disguised {@link Player} (e.g. the
+ * Slender player, see {@link net.onelitefeather.cygnus.utils.Items#setSlenderEye}) has its entity
+ * meta swapped to a non-avatar type such as {@code EndermanMeta}. Minestom's own listener always
+ * casts the meta to {@link PlayerMeta} and crashes with a {@link ClassCastException} whenever the
+ * client resends its settings while disguised, so this guards the cast instead.
+ *
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 2.7.1
+ */
+public final class CygnusSettingsListener {
+
+    private CygnusSettingsListener() {
+    }
+
+    public static void listener(ClientSettingsPacket packet, Player player) {
+        if (player.getEntityMeta() instanceof PlayerMeta) {
+            player.refreshSettings(packet.settings());
+        }
+        EventDispatcher.call(new PlayerSettingsChangeEvent(player));
+    }
+}

--- a/game/src/test/java/net/onelitefeather/cygnus/listener/CygnusSettingsListenerTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/listener/CygnusSettingsListenerTest.java
@@ -1,0 +1,75 @@
+package net.onelitefeather.cygnus.listener;
+
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.entity.MainHand;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.listener.common.SettingsListener;
+import net.minestom.server.message.ChatMessageType;
+import net.minestom.server.network.packet.client.common.ClientSettingsPacket;
+import net.minestom.server.network.player.ClientSettings;
+import net.minestom.testing.Env;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers the crash from switching a {@link Player} to a non-avatar {@link EntityType} (e.g. the
+ * Slender disguise, see {@link net.onelitefeather.cygnus.utils.Items#setSlenderEye}): Minestom's
+ * built-in {@link SettingsListener} always casts the entity meta to {@code PlayerMeta}, which
+ * blows up with a {@link ClassCastException} the next time the client resends its settings.
+ */
+@ExtendWith(MicrotusExtension.class)
+class CygnusSettingsListenerTest {
+
+    @Test
+    void testVanillaListenerCrashesOnDisguise(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+        player.switchEntityType(EntityType.ENDERMAN);
+
+        ClientSettingsPacket packet = new ClientSettingsPacket(ClientSettings.DEFAULT);
+        assertThrows(ClassCastException.class, () -> SettingsListener.listener(packet, player));
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testNoCrashOnDisguise(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+        player.switchEntityType(EntityType.ENDERMAN);
+
+        ClientSettingsPacket packet = new ClientSettingsPacket(ClientSettings.DEFAULT);
+        assertDoesNotThrow(() -> CygnusSettingsListener.listener(packet, player));
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testAppliesSettingsForRegularPlayer(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ClientSettings settings = new ClientSettings(
+                Locale.GERMANY, (byte) 10,
+                ChatMessageType.FULL, true,
+                (byte) 0x7F, MainHand.LEFT,
+                true, true,
+                ClientSettings.ParticleSetting.MINIMAL
+        );
+
+        CygnusSettingsListener.listener(new ClientSettingsPacket(settings), player);
+
+        assertEquals(MainHand.LEFT, player.getPlayerMeta().getMainHand());
+
+        env.destroyInstance(instance, true);
+    }
+}


### PR DESCRIPTION
## Proposed changes

The game disguises the Slender player as an Enderman. This causes issues with the ClientSettingsPacket, as an Enderman is not a player entity. To avoid unwanted refreshSettings calls, this pull request adds an additional guard check.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)