### PR TITLE
fix(player): switch to a virtual border

### DIFF
--- a/game/src/main/java/net/onelitefeather/cygnus/player/CygnusPlayer.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/player/CygnusPlayer.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.attribute.Attribute;
 import net.minestom.server.entity.attribute.AttributeModifier;
 import net.minestom.server.entity.attribute.AttributeOperation;
 import net.minestom.server.network.packet.server.play.EntityAttributesPacket;
-import net.minestom.server.network.packet.server.play.WorldBorderWarningReachPacket;
+import net.minestom.server.network.packet.server.play.InitializeWorldBorderPacket;
 import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.sound.SoundEvent;
@@ -17,11 +17,21 @@ import java.util.concurrent.ThreadLocalRandom;
 @SuppressWarnings("java:S3252")
 public final class CygnusPlayer extends InstanceSwitchChunkPlayer {
 
+    static final int PORTAL_TELEPORT_BOUNDARY = 29_999_984;
+
+    /**
+     * Radius (in blocks) of the virtual, per-player world border used to fake the heartbeat
+     * vignette. It is recentered on the player every tick, so the real client-side distance to
+     * its edge is always exactly this value, independent of the instance's actual world border.
+     */
+    static final double FAKE_BORDER_RADIUS = 50.0;
+    static final double FAKE_BORDER_DIAMETER = FAKE_BORDER_RADIUS * 2.0;
+
     static final AttributeModifier SPEED_MODIFIER_SPRINTING =
-            new AttributeModifier(Key.key("cygnus:sprinting"), 0.25, AttributeOperation.ADD_MULTIPLIED_TOTAL);
+            new AttributeModifier(Key.key("cygnus","sprinting"), 0.25, AttributeOperation.ADD_MULTIPLIED_TOTAL);
 
     static final AttributeModifier DISABLED_SPRINT_MODIFIER =
-            new AttributeModifier(Key.key("cygnus:sprinting"), 0.0, AttributeOperation.ADD_MULTIPLIED_TOTAL);
+            new AttributeModifier(Key.key("cygnus", "sprinting"), 0.0, AttributeOperation.ADD_MULTIPLIED_TOTAL);
 
     private static final float HEALTH_THRESHOLD = 6.0f; // 3 hearts
     private static final int MAX_INTERVAL_TICKS = 36;   // Every 1.8s (slow, subtle pulse at start)
@@ -107,21 +117,17 @@ public final class CygnusPlayer extends InstanceSwitchChunkPlayer {
 
         float intensity = Math.clamp(1.0f - (health / HEALTH_THRESHOLD), 0.0f, 1.0f);
 
-        double distanceToBorder = 29_999_984.0;
-        var instance = getInstance();
-        if (instance != null && instance.getWorldBorder() != null) {
-            var border = instance.getWorldBorder();
-            double radius = border.diameter() / 2.0;
-            double dx = Math.abs(getPosition().x() - border.centerX());
-            double dz = Math.abs(getPosition().z() - border.centerZ());
-            distanceToBorder = Math.max(1.0, radius - Math.max(dx, dz));
-        }
-
         // Non-linear visual curve makes the red border vignette stronger earlier and very intense at low HP
         float visualIntensity = (float) Math.pow(intensity, 0.6);
         float clampedIntensity = Math.min(visualIntensity, 0.995f);
-        int warningBlocks = (int) (distanceToBorder / (1.0f - clampedIntensity));
-        sendPacket(new WorldBorderWarningReachPacket(warningBlocks));
+        int warningBlocks = (int) (FAKE_BORDER_RADIUS / (1.0f - clampedIntensity));
+
+        var position = getPosition();
+        sendPacket(new InitializeWorldBorderPacket(
+                position.x(), position.z(),
+                FAKE_BORDER_DIAMETER, FAKE_BORDER_DIAMETER, 0L,
+                PORTAL_TELEPORT_BOUNDARY, 0, warningBlocks
+        ));
 
         float intervalFactor = (float) Math.pow(intensity, 0.85);
         int targetInterval = (int) (MAX_INTERVAL_TICKS - (intervalFactor * (MAX_INTERVAL_TICKS - MIN_INTERVAL_TICKS)));
@@ -151,7 +157,9 @@ public final class CygnusPlayer extends InstanceSwitchChunkPlayer {
     private void resetHeartbeat() {
         heartbeatActive = false;
         heartbeatTicks = 0;
-        sendPacket(new WorldBorderWarningReachPacket(0));
+        // Restores the real (instance-wide) world border after the per-tick fake one used for
+        // the vignette, so the client stops seeing the small virtual border we sent it.
+        sendPacket(getInstance().createInitializeWorldBorderPacket());
     }
 
     /**
@@ -163,6 +171,9 @@ public final class CygnusPlayer extends InstanceSwitchChunkPlayer {
         return heartbeatActive;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public EntityAttributesPacket getPropertiesPacket() {
         return super.getPropertiesPacket();

--- a/game/src/test/java/net/onelitefeather/cygnus/player/CygnusPlayerHeartbeatTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/player/CygnusPlayerHeartbeatTest.java
@@ -1,7 +1,10 @@
 package net.onelitefeather.cygnus.player;
 
+import net.minestom.server.coordinate.Pos;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.play.InitializeWorldBorderPacket;
 import net.minestom.testing.Env;
+import net.minestom.testing.TestConnection;
 import net.onelitefeather.cygnus.CygnusPlayerTestBase;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -19,6 +22,65 @@ class CygnusPlayerHeartbeatTest extends CygnusPlayerTestBase {
         player.tickHeartbeat();
 
         assertFalse(player.isHeartbeatActive());
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testHeartbeatSendsVirtualBorderCenteredOnPlayer(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Pos spawnPos = new Pos(120.5, 40, -75.25);
+        CygnusPlayer player = (CygnusPlayer) connection.connect(instance, spawnPos);
+
+        player.setHealth(4.0f);
+        var collector = connection.trackIncoming(InitializeWorldBorderPacket.class);
+        player.tickHeartbeat();
+
+        collector.assertSingle(packet -> {
+            assertEquals(spawnPos.x(), packet.x(), 0.001);
+            assertEquals(spawnPos.z(), packet.z(), 0.001);
+            assertEquals(100.0, packet.newDiameter(), 0.001);
+        });
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testHeartbeatWarningBlocksStayWithinIntRangeNearDeath(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        CygnusPlayer player = (CygnusPlayer) connection.connect(instance, Pos.ZERO);
+
+        player.setHealth(0.5f);
+        var collector = connection.trackIncoming(InitializeWorldBorderPacket.class);
+        player.tickHeartbeat();
+
+        collector.assertSingle(packet -> assertTrue(packet.warningBlocks() <= 10_000,
+                "warningBlocks should stay in a sane range, was " + packet.warningBlocks()));
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testHeartbeatResetRestoresRealBorder(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        CygnusPlayer player = (CygnusPlayer) connection.connect(instance, Pos.ZERO);
+
+        player.setHealth(4.0f);
+        player.tickHeartbeat();
+        assertTrue(player.isHeartbeatActive());
+
+        player.setHealth(20.0f);
+        var collector = connection.trackIncoming(InitializeWorldBorderPacket.class);
+        player.tickHeartbeat();
+
+        collector.assertSingle(packet -> {
+            assertEquals(instance.getWorldBorder().centerX(), packet.x(), 0.001);
+            assertEquals(instance.getWorldBorder().centerZ(), packet.z(), 0.001);
+            assertEquals(instance.getWorldBorder().diameter(), packet.newDiameter(), 0.001);
+        });
 
         env.destroyInstance(instance, true);
     }


### PR DESCRIPTION
## Proposed changes

The game uses the world border effect to indicate when the player has low health, but relies on the instance's world border. This causes a small issue because the effect does not account for changes to the instance's border, such as moving it. As a result, the effect becomes less effective. To avoid this, this pull request adds the usage of a virtual world border in some places.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)