### PR TITLE
feat(stats): add simple ingame statistics

### DIFF
--- a/common/src/main/java/net/onelitefeather/cygnus/common/Messages.java
+++ b/common/src/main/java/net/onelitefeather/cygnus/common/Messages.java
@@ -36,6 +36,7 @@ public final class Messages {
     private static final Component SURVIVOR_JOIN_PART_UPPER;
     private static final Component SURVIVOR_JOIN_LOWER_PART;
     public static final Component SLENDER_JOIN_PART;
+    private static final Component STATS_HEADER;
     private static final int MAP_ANNOUNCEMENT_MIN_WIDTH = 20;
 
     static {
@@ -74,6 +75,8 @@ public final class Messages {
                 .append(withPrefix(Component.text("Eliminate all survivors to win the game!", NamedTextColor.YELLOW)))
                 .append(Component.newline())
                 .append(withMiniPrefix("<red>Right-click your <color:#ff00d4>SlenderEye</color> <red>to toggle invisibility!"));
+
+        STATS_HEADER = withMini("<dark_gray>---[<gold>Statistics<dark_gray>]---");
     }
 
     private Messages() {
@@ -126,6 +129,51 @@ public final class Messages {
         var playerName = Tag.preProcessParsed(player.getUsername());
         var playerTag = TagResolver.builder().tag("player", (argumentQueue, context) -> playerName).build();
         return PREFIX.append(Component.space()).append(withMini("<red><player> <color:#249D9F>was</color> <color:#ff0000>TAKEN!</color>", playerTag));
+    }
+
+    /**
+     * Builds the round-end stats box for a survivor.
+     *
+     * @param player     the survivor the box is about
+     * @param pageFounds how many pages the survivor found this round
+     * @param died       whether the survivor died this round
+     * @return the formatted stats box
+     */
+    @Contract(value = "_, _, _ -> new", pure = true)
+    public static Component getSurvivorRoundSummaryComponent(Player player, int pageFounds, boolean died) {
+        Component deathIcon = died
+                ? Component.text("✓", NamedTextColor.GREEN)
+                : Component.text("✗", NamedTextColor.RED);
+        var resolver = TagResolver.builder()
+                .tag("pages", (_, _) -> Tag.preProcessParsed(String.valueOf(pageFounds)))
+                .tag("died", Tag.inserting(deathIcon))
+                .build();
+        return Component.text(player.getUsername(), NamedTextColor.GOLD)
+                .append(Component.newline())
+                .append(STATS_HEADER)
+                .append(Component.newline())
+                .append(withMini("<gray>Pages: <green><pages>", resolver))
+                .append(Component.newline())
+                .append(withMini("<gray>Death: <died>", resolver));
+    }
+
+    /**
+     * Builds the round-end stats box for the slender.
+     *
+     * @param player the slender the box is about
+     * @param kills  how many survivors the slender caught this round
+     * @return the formatted stats box
+     */
+    @Contract(value = "_, _ -> new", pure = true)
+    public static Component getSlenderRoundSummaryComponent(Player player, int kills) {
+        var resolver = TagResolver.builder()
+                .tag("kills", (_, _) -> Tag.preProcessParsed(String.valueOf(kills)))
+                .build();
+        return Component.text(player.getUsername(), NamedTextColor.GOLD)
+                .append(Component.newline())
+                .append(STATS_HEADER)
+                .append(Component.newline())
+                .append(withMini("<gray>Kills: <green><kills>", resolver));
     }
 
 

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerDeathListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/PlayerDeathListener.java
@@ -14,6 +14,7 @@ import net.onelitefeather.cygnus.entity.DeadPlayerMannequin;
 import net.onelitefeather.cygnus.event.GameFinishEvent;
 import net.onelitefeather.cygnus.jumpscare.JumpScareManager;
 import net.onelitefeather.cygnus.phase.GamePhase;
+import net.onelitefeather.cygnus.player.CygnusPlayer;
 import net.onelitefeather.cygnus.player.event.SpectatorAddEvent;
 
 import java.util.function.Consumer;
@@ -39,7 +40,12 @@ public final class PlayerDeathListener implements Consumer<PlayerDeathEvent> {
     public void accept(PlayerDeathEvent event) {
         Player player = event.getPlayer();
 
-        if (survivorTeam.getPlayers().contains(player) && player.getInstance() != null) {
+        if (survivorTeam.getPlayers().contains(player)) {
+            ((CygnusPlayer) player).setDeath(true);
+            this.slenderTeam.getPlayers().stream().findFirst()
+                    .ifPresent(slender -> ((CygnusPlayer) slender).incrementKills());
+
+            if (player.getInstance() == null) return;
             Pos deathPos = player.getPosition();
             DeadPlayerMannequin mannequin = DeadPlayerMannequin.sleeping(player);
             mannequin.setInstance(player.getInstance(), deathPos.add(0, 0.15, 0));

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/game/GameFinishListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/game/GameFinishListener.java
@@ -2,8 +2,12 @@ package net.onelitefeather.cygnus.listener.game;
 
 import net.theevilreaper.aves.util.Broadcaster;
 import net.kyori.adventure.text.Component;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Player;
 import net.onelitefeather.cygnus.common.Messages;
 import net.onelitefeather.cygnus.event.GameFinishEvent;
+import net.onelitefeather.cygnus.player.CygnusPlayer;
+import net.onelitefeather.cygnus.team.TeamHelper;
 
 import java.util.function.Consumer;
 
@@ -19,5 +23,23 @@ public final class GameFinishListener implements Consumer<GameFinishEvent> {
             case TIME_OVER, ALL_PAGES_FOUND, SLENDER_LEFT -> Messages.SURVIVOR_WIN_MESSAGE;
         };
         Broadcaster.broadcast(endComponent);
+        Broadcaster.broadcast(buildRoundSummary());
+    }
+
+    /**
+     * Builds a per-player summary of this round's stats, one line per {@link CygnusPlayer} online.
+     *
+     * @return the summary component
+     */
+    private Component buildRoundSummary() {
+        Component summary = Component.empty();
+        for (Player onlinePlayer : MinecraftServer.getConnectionManager().getOnlinePlayers()) {
+            if (!(onlinePlayer instanceof CygnusPlayer cygnusPlayer)) continue;
+            Component box = TeamHelper.isSlenderTeam(onlinePlayer)
+                    ? Messages.getSlenderRoundSummaryComponent(onlinePlayer, cygnusPlayer.getKills())
+                    : Messages.getSurvivorRoundSummaryComponent(onlinePlayer, cygnusPlayer.getPageFounds(), cygnusPlayer.hasDied());
+            summary = summary.append(Component.newline()).append(box);
+        }
+        return summary;
     }
 }

--- a/game/src/main/java/net/onelitefeather/cygnus/listener/page/PlayerPageInteractListener.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/listener/page/PlayerPageInteractListener.java
@@ -5,6 +5,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.event.player.PlayerEntityInteractEvent;
 import net.onelitefeather.cygnus.common.Tags;
 import net.onelitefeather.cygnus.common.page.PageProvider;
+import net.onelitefeather.cygnus.player.CygnusPlayer;
 import net.onelitefeather.cygnus.team.TeamHelper;
 
 import java.util.UUID;
@@ -24,6 +25,7 @@ public class PlayerPageInteractListener implements Consumer<PlayerEntityInteract
         Entity target = event.getTarget();
         if (!TeamHelper.isSurvivorTeam(player) || !target.hasTag(Tags.PAGE_TAG)) return;
         UUID uuid = target.getTag(Tags.PAGE_TAG);
+        ((CygnusPlayer) player).incrementPageFound();
         pageProvider.triggerPageFound(player, uuid);
     }
 }

--- a/game/src/main/java/net/onelitefeather/cygnus/player/CygnusPlayer.java
+++ b/game/src/main/java/net/onelitefeather/cygnus/player/CygnusPlayer.java
@@ -41,11 +41,18 @@ public final class CygnusPlayer extends InstanceSwitchChunkPlayer {
     private int heartbeatTicks;
     private boolean heartbeatActive;
 
+    private int pageFounds;
+    private int kills;
+    private boolean death;
+
     public CygnusPlayer(PlayerConnection playerConnection, GameProfile gameProfile) {
         super(playerConnection, gameProfile);
         this.blockedSprinting = false;
         this.heartbeatTicks = 0;
         this.heartbeatActive = false;
+        this.pageFounds = 0;
+        this.kills = 0;
+        this.death = false;
     }
 
     /**
@@ -98,6 +105,56 @@ public final class CygnusPlayer extends InstanceSwitchChunkPlayer {
      */
     public boolean hasBlockedSprinting() {
         return blockedSprinting;
+    }
+
+    /**
+     * Increments the number of pages this player has found in the current round.
+     */
+    public void incrementPageFound() {
+        this.pageFounds++;
+    }
+
+    /**
+     * Returns how many pages this player has found in the current round.
+     *
+     * @return the page count
+     */
+    public int getPageFounds() {
+        return pageFounds;
+    }
+
+    /**
+     * Increments the number of survivors this player has killed in the current round.
+     */
+    public void incrementKills() {
+        this.kills++;
+    }
+
+    /**
+     * Returns how many survivors this player has killed in the current round.
+     *
+     * @return the kill count
+     */
+    public int getKills() {
+        return kills;
+    }
+
+    /**
+     * Marks whether this player died during the current round.
+     *
+     * @param death {@code true} if the player died this round
+     */
+    public void setDeath(boolean death) {
+        this.death = death;
+    }
+
+    /**
+     * Checks if the player died during the current round.
+     *
+     * @return {@code true} if the player died this round, otherwise {@code false}.
+     */
+    public boolean hasDied() {
+        return death;
     }
 
     /**

--- a/game/src/test/java/net/onelitefeather/cygnus/listener/PlayerDeathListenerTest.java
+++ b/game/src/test/java/net/onelitefeather/cygnus/listener/PlayerDeathListenerTest.java
@@ -8,14 +8,15 @@ import net.onelitefeather.cygnus.CygnusPlayerTestBase;
 import net.onelitefeather.cygnus.common.Tags;
 import net.onelitefeather.cygnus.common.config.GameConfig;
 import net.onelitefeather.cygnus.jumpscare.JumpScareManager;
+import net.onelitefeather.cygnus.player.CygnusPlayer;
 import net.onelitefeather.cygnus.player.event.SpectatorAddEvent;
-import net.onelitefeather.cygnus.team.TeamHelper;
-import net.theevilreaper.xerus.api.team.Team;
+ import net.theevilreaper.xerus.api.team.Team;
 import net.theevilreaper.xerus.api.team.TeamService;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PlayerDeathListenerTest extends CygnusPlayerTestBase {
 
@@ -39,6 +40,55 @@ class PlayerDeathListenerTest extends CygnusPlayerTestBase {
                 .followup(event -> assertEquals(player, event.getPlayer()));
 
         listener.accept(new PlayerDeathEvent(player, null, null));
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testDyingSurvivorIsMarkedAsDied(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        CygnusPlayer player = (CygnusPlayer) env.createPlayer(instance);
+
+        TeamService teamService = TeamService.of();
+        Team slenderTeam = Team.of(GameConfig.SLENDER_KEY, 1);
+        Team survivorTeam = Team.of(GameConfig.SURVIVOR_KEY, 5);
+        teamService.add(slenderTeam);
+        teamService.add(survivorTeam);
+
+        survivorTeam.addPlayer(player);
+        player.setTag(Tags.TEAM_KEY, GameConfig.SURVIVOR_KEY);
+
+        PlayerDeathListener listener = new PlayerDeathListener(() -> null, teamService, new JumpScareManager());
+
+        listener.accept(new PlayerDeathEvent(player, null, null));
+
+        assertTrue(player.hasDied());
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testDyingSurvivorIncrementsSlenderKills(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        CygnusPlayer survivor = (CygnusPlayer) env.createPlayer(instance);
+        CygnusPlayer slender = (CygnusPlayer) env.createPlayer(instance);
+
+        TeamService teamService = TeamService.of();
+        Team slenderTeam = Team.of(GameConfig.SLENDER_KEY, 1);
+        Team survivorTeam = Team.of(GameConfig.SURVIVOR_KEY, 5);
+        teamService.add(slenderTeam);
+        teamService.add(survivorTeam);
+
+        survivorTeam.addPlayer(survivor);
+        survivor.setTag(Tags.TEAM_KEY, GameConfig.SURVIVOR_KEY);
+        slenderTeam.addPlayer(slender);
+        slender.setTag(Tags.TEAM_KEY, GameConfig.SLENDER_KEY);
+
+        PlayerDeathListener listener = new PlayerDeathListener(() -> null, teamService, new JumpScareManager());
+
+        listener.accept(new PlayerDeathEvent(survivor, null, null));
+
+        assertEquals(1, slender.getKills());
 
         env.destroyInstance(instance, true);
     }


### PR DESCRIPTION
## Proposed changes

Currently, the game does not provide any kind of statistics. Before introducing a dedicated statistics module, it makes sense to integrate some basic in game statistics first. This pull request collects several metrics during a game and displays them to the player once the game has ended. The collected data is not stored in a file or database, as persistent storage will be implemented in a separate step.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)